### PR TITLE
Add bulk JSON import & export for link patterns

### DIFF
--- a/options/options.css
+++ b/options/options.css
@@ -1,0 +1,54 @@
+body {
+    font-family: sans-serif;
+    color: rgb(201, 209, 217);
+    background-color: rgb(22, 27, 34);
+    color-scheme: dark;
+}
+
+/* Generic Input Styles */
+button:hover,
+input[type="checkbox"]:enabled:hover,
+input[type="file"],
+input[type=file]::-webkit-file-upload-button,
+select {
+    /* Found solution for "Choose File" button not applying styles here:
+    https://stackoverflow.com/questions/1537223/change-cursor-type-on-input-type-file */
+    cursor: pointer;
+    background-color: rgb(39, 44, 51);
+}
+
+button {
+    border-radius: 4px;
+    padding: 2px 12px;
+    background-color: rgb(33, 38, 45);
+    border-color: rgba(240, 246, 252, 0.1);
+    color: rgb(201, 209, 217);
+}
+
+input[type="text"] {
+    cursor: text;
+}
+
+.input-container-import-export label {
+    font-weight: bold;
+}
+
+/* Table Styles */
+table#table-link-patterns {
+    border-collapse: collapse;
+}
+
+table#table-link-patterns td, table#table-link-patterns th {
+    border: 1px solid rgb(201, 209, 217);
+    text-align: center;
+}
+
+table#table-link-patterns td {
+    padding: 5px 10px;
+}
+
+table#table-link-patterns th {
+    font-size: 15px;
+    background-color: rgb(32, 37, 45);
+    padding: 10px;
+}

--- a/options/options.html
+++ b/options/options.html
@@ -14,10 +14,22 @@
         <button id="save-button">Save</button>
     </div>
     <div id="input-container-attachments" class="input-container"></div>
-    
 
     <div id="table-container-link-patterns">
     <h1>Saved Link Patterns</h1>
+    <div id="input-container-link-patterns-import-export">
+        <div id="input-container-link-patterns-import">
+            <label for="input-link-patterns-import">Import</label>
+            <input type="file" id="input-link-patterns-import-file" name="input-link-patterns-import-file" accept=".json">
+            <label for="input-link-patterns-import-type">Import Type</label>
+            <select id="input-link-patterns-import-type" name="input-link-patterns-import-type">
+                <option value="append" selected>Append</option>
+                <option value="overwrite">Overwrite</option>
+            </select>
+            <button type="button" id="input-link-patterns-import">Import</button>
+        </div>
+        <button type="button" id="input-link-patterns-export">Export</button>
+    </div>
         <table id="table-link-patterns">
             <thead>
             <tr>

--- a/options/options.html
+++ b/options/options.html
@@ -17,19 +17,6 @@
 
     <div id="table-container-link-patterns">
     <h1>Saved Link Patterns</h1>
-    <div id="input-container-link-patterns-import-export">
-        <div id="input-container-link-patterns-import">
-            <label for="input-link-patterns-import">Import</label>
-            <input type="file" id="input-link-patterns-import-file" name="input-link-patterns-import-file" accept=".json">
-            <label for="input-link-patterns-import-type">Import Type</label>
-            <select id="input-link-patterns-import-type" name="input-link-patterns-import-type">
-                <option value="append" selected>Append</option>
-                <option value="overwrite">Overwrite</option>
-            </select>
-            <button type="button" id="input-link-patterns-import">Import</button>
-        </div>
-        <button type="button" id="input-link-patterns-export">Export</button>
-    </div>
         <table id="table-link-patterns">
             <thead>
             <tr>
@@ -43,6 +30,18 @@
             <tbody>
             </tbody>
         </table>
+    </div>
+    <h2>Import/Export</h2>
+    <div class="input-container input-container-import-export" id="input-container-link-patterns-import-export">
+        <label for="link-patterns-import-file">Import File: </label>
+        <input type="file" id="link-patterns-import-file" name="link-patterns-import-file" accept=".json">
+        <label for="link-patterns-import-type">Import Type: </label>
+        <select id="link-patterns-import-type" name="link-patterns-import-type">
+            <option value="append" selected>Append</option>
+            <option value="overwrite">Overwrite</option>
+        </select>
+        <button type="button" id="link-patterns-import">Import</button>
+        <button type="button" id="link-patterns-export">Export</button>
     </div>
     <script type="application/javascript" src="../lib/browser-polyfill.min.js"></script>
 	<script type="application/javascript" src="options.js"></script>

--- a/options/options.js
+++ b/options/options.js
@@ -167,18 +167,18 @@ function downloadLinkPatternsJSON() {
   }
 
 function importLinkPatternsJSON() {
-    const inputElement = document.getElementById('input-link-patterns-import-file'); 
+    const inputElement = document.getElementById('link-patterns-import-file'); 
     const file = inputElement.files[0];
     const fileReader = new FileReader();
 
     // Clear input.
-    document.getElementById('input-link-patterns-import-file').value = "";
+    document.getElementById('link-patterns-import-file').value = "";
 
     fileReader.readAsText(file, 'UTF-8');
     fileReader.onload = function() {
         const fileContent = fileReader.result;
         const newOptions = JSON.parse(fileContent);
-        const overwrite = (document.getElementById('input-link-patterns-import-type').value == 'overwrite') ? true : false;
+        const overwrite = (document.getElementById('link-patterns-import-type').value == 'overwrite') ? true : false;
         // Validate the JSON data.
 
         newOptions.forEach(option => {
@@ -224,7 +224,7 @@ function importLinkPatternsJSON() {
 
 document.addEventListener("DOMContentLoaded", () => {
     document.getElementById('save-button').addEventListener('click', () => save());
-    document.getElementById('input-link-patterns-import').addEventListener('click', () => importLinkPatternsJSON());
-    document.getElementById('input-link-patterns-export').addEventListener('click', () => downloadLinkPatternsJSON());
+    document.getElementById('link-patterns-import').addEventListener('click', () => importLinkPatternsJSON());
+    document.getElementById('link-patterns-export').addEventListener('click', () => downloadLinkPatternsJSON());
     load();
 });

--- a/options/options.js
+++ b/options/options.js
@@ -105,7 +105,7 @@ function save() {
             return;
         }
         data.options.push({
-            id: Date.now(),
+            id: crypto.randomUUID(),
             title: document.getElementById('title').value,
             pattern: document.getElementById('pattern').value,
             showParent: document.getElementById('show-parent').checked
@@ -181,7 +181,6 @@ function importLinkPatternsJSON() {
         const overwrite = (document.getElementById('input-link-patterns-import-type').value == 'overwrite') ? true : false;
         // Validate the JSON data.
 
-        let i = Date.now();
         newOptions.forEach(option => {
             // Check for missing fields.
             if (option.id == undefined || option.title == undefined || option.pattern == undefined || option.showParent == undefined) {
@@ -189,7 +188,7 @@ function importLinkPatternsJSON() {
                 return;
             }
             // Always set new ID to avoid duplicates.
-            option.id = i++;
+            option.id = crypto.randomUUID();
             // Validate RegEx.
             try {
                 new RegExp(option.pattern);

--- a/options/options.js
+++ b/options/options.js
@@ -97,6 +97,13 @@ function save() {
         if (data.options == undefined || data.options.length <= 0) {
             data.options = [];
         }
+        // Validate RegEx.
+        try {
+            new RegExp(document.getElementById('pattern').value);
+        } catch (SyntaxError) {
+            console.error("Invalid RegEx");
+            return;
+        }
         data.options.push({
             id: Date.now(),
             title: document.getElementById('title').value,
@@ -181,8 +188,10 @@ function importLinkPatternsJSON() {
             }
             // Always set new ID to avoid duplicates.
             option.id = i++;
-            // Validate RegEx is valid.
-            if (new RegExp(option.pattern) == undefined) {
+            // Validate RegEx.
+            try {
+                new RegExp(option.pattern);
+            } catch (SyntaxError) {
                 console.error("Invalid JSON data (bad pattern)");
                 return;
             }

--- a/options/options.js
+++ b/options/options.js
@@ -171,8 +171,10 @@ function importLinkPatternsJSON() {
     const file = inputElement.files[0];
     const fileReader = new FileReader();
 
-    fileReader.readAsText(file, 'UTF-8');
+    // Clear input.
+    document.getElementById('input-link-patterns-import-file').value = "";
 
+    fileReader.readAsText(file, 'UTF-8');
     fileReader.onload = function() {
         const fileContent = fileReader.result;
         const newOptions = JSON.parse(fileContent);
@@ -196,7 +198,8 @@ function importLinkPatternsJSON() {
                 return;
             }
         });
-        
+
+        // Add to existing data.
         if (!overwrite) {
             browser.storage.sync.get('options').then(data => {
                 if (data.options == undefined || data.options.length <= 0) {

--- a/popup/popup.css
+++ b/popup/popup.css
@@ -38,11 +38,11 @@ a:hover {
     flex: 1;
     background-color: rgb(33, 38, 45);
     border-color: rgba(240, 246, 252, 0.1);
+    color: rgb(201, 209, 217);
     border-radius: 6px;
     border-width: 1px;
     border-style: solid;
     text-decoration: none;
-    color: rgb(201, 209, 217);
 }
 
 #container {


### PR DESCRIPTION
- Adds import & export functionality for link patterns. Link patterns are imported/exported as JSON. 
    - Patterns can be imported in `Append` or `Overwrite` modes. 
- Adds RegEx validation on manual input and file import. This prevents breaking the extension from loading when an invalid RegEx pattern is saved. 
- Adds stylesheet to options page (now a darker colour scheme).

Resolves #14 