### PR TITLE
Fix HTML tags showing in the links lists when link has child elements.

### DIFF
--- a/popup/popup.js
+++ b/popup/popup.js
@@ -56,7 +56,7 @@ async function displayLinks(commentsJSON) {
                         id: comments.id,
                         created_at: comments.created_at,
                         parent_text: link.parentElement.innerHTML,
-                        text: link.innerHTML,
+                        text: link.innerText,
                         href: link.href
                       })
             });
@@ -212,6 +212,7 @@ async function filterLinks(linksArr) {
   // This is an array of objects with the following structure:
   // {
   //   title: "",
+  //   showParent: true/false,
   //   links: []
   // }
   const filteredLinks = [];


### PR DESCRIPTION
This PR fixes HTML tags showing in the links lists.

Example:

Before: `This is a <em>strong</em> sentence with <code>code blocks</code>.`
Now: `This is a strong sentence with code blocks`

Resolves #13  