### PR TITLE
Add tooltip hover for links in extension UI

### DIFF
--- a/popup/popup.css
+++ b/popup/popup.css
@@ -166,7 +166,7 @@ h3.list-header {
 }
 
 /* Remove unused space between headers and the view buttons */
-#list-container-links h3:nth-child(1), #list-container-attachments ul:nth-child(1) {
+#list-container-links h3:first-of-type, #list-container-attachments ul:first-of-type {
     margin-top: 0;
 }
 

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -126,6 +126,7 @@ async function displayLinks(commentsJSON) {
           // Otherwise, they do not open in a tab.
           doc.querySelectorAll(`a`).forEach(a => {
             a.setAttribute('target', '_blank');
+            a.setAttribute('title' , a.href);
           });
           
           // Get all the body because that's all we care about.
@@ -150,6 +151,7 @@ async function displayLinks(commentsJSON) {
           const a = document.createElement('a');
           a.setAttribute('target', '_blank');
           a.setAttribute('href', link.href);
+          a.setAttribute('title' , link.href);
           a.textContent = link.text;
           li.appendChild(a);
         }


### PR DESCRIPTION
This PR adds the `title` attribute to links. This allows you to see the link `href` (the URL) while hovering over the link.