### PR TITLE
Add copy link to markdown button, and start removing duplicates from found links

### DIFF
--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -117,12 +117,12 @@ a:hover {
 }
 
 /* This class is un-set by JavaScript */
-.icon.hidden {
+.icon-button.hidden {
     display: none;
     transition: opacity 0.3s ease-in-out;
 }
 
-.icon {
+.icon-button {
     opacity: 1;
     transition: opacity 0.3s ease-in-out;
 }
@@ -266,20 +266,27 @@ li.list-item-attachments ul li {
 }
 
 /* Search/Scroll-to icon styles */
-.icon-search:hover {
+.icon-li:hover {
     cursor: pointer;
 }
 
-.icon-search:hover {
+.icon-li:hover {
     filter: invert(96%) sepia(1%) saturate(4016%) hue-rotate(179deg) brightness(93%) contrast(82%);
 }
 
-.icon-search {
-    background-image: url(../icons/search.svg);
+.icon-li {
     background-repeat: no-repeat;
     filter: invert(1);
     display: inline-block;
     padding: 6px;
     margin-right: 4px;
     vertical-align: middle;
+}
+
+.icon-copy {
+    background-image: url(../icons/copy.svg);
+}
+
+.icon-search {
+    background-image: url(../icons/search.svg);
 }

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -13,7 +13,7 @@
       </a>
     </div>
     <div class="row row-links selected">
-      <a href="#" class="button button-sub" id="button-summary">
+      <a href="#" title="Copy a configurable summary to clipboard in markdown. See the options page for configuration options." class="button button-sub" id="button-summary">
         <img class="icon-button hidden" id="summary-check" src="../icons/check.svg" width="15px" height="15px">
         <img class="icon-button icon-invert" id="summary-copy" src="../icons/copy.svg" width="15px" height="15px">
         <span id="summary-text">Summary</span>

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -14,8 +14,8 @@
     </div>
     <div class="row row-links selected">
       <a href="#" class="button button-sub" id="button-summary">
-        <img class="icon hidden" id="summary-check" src="../icons/check.svg" width="15px" height="15px">
-        <img class="icon icon-invert" id="summary-copy" src="../icons/copy.svg" width="15px" height="15px">
+        <img class="icon-button hidden" id="summary-check" src="../icons/check.svg" width="15px" height="15px">
+        <img class="icon-button icon-invert" id="summary-copy" src="../icons/copy.svg" width="15px" height="15px">
         <span id="summary-text">Summary</span>
       </a>
     </div>

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -320,11 +320,29 @@ async function filterLinks(linksArr) {
         filteredLinksArr.push(link);
       }
     })
-    if (filteredLinksArr.length > 0) {
+
+    // Remove duplicates. Keep the latest.
+    const filteredLinksArrUnique = [];
+    filteredLinksArr.forEach(link => {
+      const found = filteredLinksArrUnique.find(l => l.href == link.href);
+      // If not found, add to uniques array.
+      if (found == undefined) {
+        filteredLinksArrUnique.push(link);
+      // If found, compare createdAt dates and keep the latest.
+      } else 
+      if (link.createdAt > found.createdAt) {
+        filteredLinksArrUnique.push(link);
+        filteredLinksArrUnique.splice(filteredLinksArrUnique.indexOf(found), 1);
+        console.log("Removing duplicate link: " + link.href);
+      }
+    });
+
+    
+    if (filteredLinksArrUnique.length > 0) {
       filteredLinks.push({
         title: filter.title,
         showParent: filter.showParent,
-        links: filteredLinksArr
+        links: filteredLinksArrUnique
       });
     }
   })

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -175,15 +175,18 @@ async function displayLinks(commentsJSON) {
             if (node.nodeType == Node.TEXT_NODE) {
               const span = document.createElement('span');
               span.textContent = node.textContent;
-              span.setAttribute('class', 'link-context');
+              // span.setAttribute('class', 'link-context');
               nodes.push(span);
             } else {
               nodes.push(node);
-            }            
+            }
           });
 
           // Append all nodes to list item.
-          li.append(...nodes);
+          const spanContext = document.createElement('span');
+          spanContext.setAttribute('class', 'link-context');
+          spanContext.append(...nodes);
+          li.append(spanContext);
         } else {
           const a = document.createElement('a');
           a.setAttribute('target', '_blank');

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -163,7 +163,7 @@ async function displayLinks(commentsJSON) {
           // Otherwise, they do not open in a tab.
           doc.querySelectorAll(`a`).forEach(a => {
             a.setAttribute('target', '_blank');
-            a.setAttribute('title' , a.href);
+            a.setAttribute('title' , `URL: ${a.href}\n\nComment created at: ${li.getAttribute('data-created-at')}`);
           });
           
           // Get all the body because that's all we care about.
@@ -188,7 +188,7 @@ async function displayLinks(commentsJSON) {
           const a = document.createElement('a');
           a.setAttribute('target', '_blank');
           a.setAttribute('href', link.href);
-          a.setAttribute('title' , link.href);
+          a.setAttribute('title' , `URL: ${a.href}\n\nComment created at: ${li.getAttribute('data-created-at')}`);
           a.textContent = link.text;
           li.appendChild(a);
         }

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -4,6 +4,7 @@ function scrollToComment(data) {
   });
 }
 
+// Write the configurable summary to the clipboard.
 function writeSummaryClipboard() {
   let summary = "";
   document.querySelectorAll('.list-links').forEach(list => {
@@ -11,14 +12,14 @@ function writeSummaryClipboard() {
     if (list.getAttribute('data-summary-type') == "all") {
       summary += `### ${list.getAttribute('data-title')}\n\n`;
       list.childNodes.forEach(li => {
-        summary += `- [${li.textContent}](${li.querySelector('a').href}) - _${li.getAttribute('data-created-at')}_\n`;
+        summary += `- [${li.textContent}](${li.querySelector('a').href}) - ${li.getAttribute('data-created-at')}\n`;
       });
       summary += "\n";
     // If "latest" summary type, add only the latest to summary.
     } else if (list.getAttribute('data-summary-type') == "latest") {
       summary += `### ${list.getAttribute('data-title')} (Latest)\n\n`;
       const latest = list.childNodes[list.childNodes.length - 1];
-      summary += `- [${latest.textContent}](${latest.querySelector('a').href}) - _${latest.getAttribute('data-created-at')}_\n`;
+      summary += `- [${latest.textContent}](${latest.querySelector('a').href}) - ${latest.getAttribute('data-created-at')}\n`;
       summary += "\n";
     }
 
@@ -37,6 +38,11 @@ function writeSummaryClipboard() {
   }
 }
 
+//Write a link to the clipboard in markdown format.
+function writeLinkClipboard(text, href) {
+  const link = `[${text}](${href})`;
+  navigator.clipboard.writeText(link);
+}
 
 // Code from https://stackoverflow.com/questions/55214828/how-to-make-a-cross-origin-request-in-a-content-script-currently-blocked-by-cor/55215898#55215898
 async function fetchResource(input, init) {
@@ -132,12 +138,19 @@ async function displayLinks(commentsJSON) {
         li.setAttribute('data-created-at', link.createdAt);
         li.setAttribute('data-summary-type', link.summaryType);
 
-        // Create the icon and append to list item.
-        const i = document.createElement('i');
-        i.setAttribute('class', 'icon-search');
-        i.setAttribute('commentID', link.commentID);
-        i.setAttribute('auditID', link.auditID);
-        li.appendChild(i);
+        // Create the scroll icon and append to list item.
+        const iScroll = document.createElement('i');
+        iScroll.setAttribute('class', 'icon-invert icon-li icon-search');
+        iScroll.setAttribute('commentID', link.commentID);
+        iScroll.setAttribute('auditID', link.auditID);
+        iScroll.setAttribute('title', 'Scroll to link\'s source comment.');
+        li.appendChild(iScroll);
+
+        // Create the copy to markdown icon and append to list item.
+        const iCopy = document.createElement('i');
+        iCopy.setAttribute('class', 'icon-invert icon-li icon-copy');
+        iCopy.setAttribute('title', 'Copy link to markdown.');
+        li.appendChild(iCopy);
 
         // Add link content or parent context to list item.
         if (bundle.showParent) {
@@ -188,7 +201,7 @@ async function displayLinks(commentsJSON) {
       }
     })
     
-    document.getElementById('list-container-links').querySelectorAll('i').forEach(i => {
+    document.getElementById('list-container-links').querySelectorAll('i.icon-search').forEach(i => {
       i.addEventListener('click', () => {
         scrollToComment(
           {
@@ -197,7 +210,15 @@ async function displayLinks(commentsJSON) {
           }
         )
       });
-    })
+    });
+
+    document.getElementById('list-container-links').querySelectorAll('i.icon-copy').forEach(i => {
+      i.addEventListener('click', () => {
+        const href = i.parentElement.querySelector('a').href;
+        const text = i.parentElement.textContent;
+        writeLinkClipboard(text, href);
+      });
+    });
 }
 
 async function displayAttachments(commentsJSON) {

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -255,7 +255,7 @@ async function displayAttachments(commentsJSON) {
 
     // Create the icon and append to list item.
     const i = document.createElement('i');
-    i.setAttribute('class', 'icon-search');
+    i.setAttribute('class', 'icon-invert icon-li icon-search');
     i.setAttribute('commentID', comment.commentID);
     i.setAttribute('auditID', comment.auditID);
     liDate.append(i, txtDate);


### PR DESCRIPTION
- Adds a button to copy individual links to the clipboard in markdown format. Resolves #40 
- Duplicate links (duplicate `href` values) are now removed from the extension UI and the markdown summary. The most recent occurrence of the link is kept. Related to #42 
- Add tooltip popup to summary button.
- Add comment creation date to each link's tooltip.