### PR TITLE
Add fallback option for "scroll to comment" feature to more consistently scroll to comments across all Zendesk workspace types

### DIFF
--- a/src/content-scripts/contentscript.js
+++ b/src/content-scripts/contentscript.js
@@ -1,8 +1,7 @@
-console.log("loaded content script");
+console.log("Zendesk Link Collector - loaded content script");
 browser.runtime.onMessage.addListener(function(request, sender, sendResponse) {
   // Scroll to the comment.
   if (request.type == "scroll") {
-    
     const element = document.querySelector(`[data-comment-id="${request.commentID}"]`) 
     // Older Zendesk versions.
     ? document.querySelector(`[data-comment-id="${request.commentID}"]`)
@@ -10,7 +9,28 @@ browser.runtime.onMessage.addListener(function(request, sender, sendResponse) {
     : document.querySelector(`[id="comment-${request.auditID}"]`);
     if (element) {
         element.scrollIntoView({ behavior: "smooth", block: "center" });
+        return;
     }
+
+    // Last resort, sometimes zendesk does not add the data-comment-id or id attributes to the comments.
+    // Get the comment from the audits endpoint, find the comment with the same HTML in the DOM and scroll to it.
+    const url = new URL(document.URL);
+    const urlArr = url.href.split('/');
+    const ticketID = urlArr[urlArr.length - 1];
+
+    fetch(`${url.protocol}//${url.hostname}/api/v2/tickets/${ticketID}/audits/${request.auditID}`).then(async function(response) {
+      const data = await response.json();
+      document.querySelectorAll('.zd-comment').forEach((comment) => {
+        data.audit.events.forEach((event) => {
+          if (event.type == 'Comment') {
+            if (comment.outerHTML == event.html_body) {
+              comment.scrollIntoView({ behavior: "smooth", block: "center" });
+              return;
+            }
+          }
+        });
+      });
+    });
   }
   // Code from https://stackoverflow.com/questions/55214828/how-to-make-a-cross-origin-request-in-a-content-script-currently-blocked-by-cor/55215898#55215898
   if (request.type == 'fetch') {


### PR DESCRIPTION
Add a last resort option to ensure "scroll to comment" functionality works in Zendesk's Agent Workspace. 

Sometimes Zendesk will not put comment or audit IDs in the ticket's HTML, making this "fast" method of scrolling impossible.

To ensure we can always scroll to the comment, the extension will now fall back to this behavior when it can't find an element to scroll to, based on either the comment or audit ID: 

- Using the `audits` API endpoint, get the audit events associated with the comment's audit ID.
- Scroll to the first comment that exactly matches the HTML of an audit event of type `comment`.

This will involve a slight delay, because the audit API endpoint must be called when the scroll button is clicked.