### PR TITLE
Split manifests for different browsers, allowing the development of background tasks (custom keybinds and other browser-specific features)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# ZLC Specific
+build
+
 # General
 .DS_Store
 .AppleDouble

--- a/makefile
+++ b/makefile
@@ -48,7 +48,7 @@ build-chrome:
 lint-firefox:
 	$(WE) lint --source-dir=$(FIREFOX_BUILD_DIR)
 
-# Lint for Chrome with web-ext
+# Lint for Chrome with web-ext (will produce warnings)
 lint-chrome:
 	$(WE) lint --source-dir=$(CHROME_BUILD_DIR)
 

--- a/makefile
+++ b/makefile
@@ -1,0 +1,56 @@
+# Makefile
+
+# Directories
+SRC_DIR = src
+BUILD_DIR = build
+FIREFOX_BUILD_DIR = $(BUILD_DIR)/firefox
+CHROME_BUILD_DIR = $(BUILD_DIR)/chrome
+
+# Commands
+MKDIR_P = mkdir -p
+RM = rm -rf
+CP = cp -r
+MV = mv
+WE = web-ext
+
+.PHONY: all clean firefox chrome build lint
+
+# Build with web-ext
+all: prep-firefox prep-chrome build-firefox build-chrome
+build: all
+
+# Lint with web-ext
+lint: prep-firefox prep-chrome lint-firefox lint-chrome
+
+# Prep build directories for Firefox
+prep-firefox:
+	$(MKDIR_P) $(FIREFOX_BUILD_DIR)
+	$(CP) $(SRC_DIR)/* $(FIREFOX_BUILD_DIR)
+	$(MV) $(FIREFOX_BUILD_DIR)/manifest-firefox.json $(FIREFOX_BUILD_DIR)/manifest.json
+	$(RM) $(FIREFOX_BUILD_DIR)/manifest-chrome.json
+
+# Prep build directories for Chrome
+prep-chrome:
+	$(MKDIR_P) $(CHROME_BUILD_DIR)
+	$(CP) $(SRC_DIR)/* $(CHROME_BUILD_DIR)
+	$(MV) $(CHROME_BUILD_DIR)/manifest-chrome.json $(CHROME_BUILD_DIR)/manifest.json
+	$(RM) $(CHROME_BUILD_DIR)/manifest-firefox.json
+
+# Build for Firefox with web-ext
+build-firefox:
+	$(WE) build --source-dir=$(FIREFOX_BUILD_DIR) --artifacts-dir=$(FIREFOX_BUILD_DIR)/artifacts
+
+# Build for Chrome with web-ext
+build-chrome:
+	$(WE) build --source-dir=$(CHROME_BUILD_DIR) --artifacts-dir=$(CHROME_BUILD_DIR)/artifacts
+
+# Lint for Firefox with web-ext
+lint-firefox:
+	$(WE) lint --source-dir=$(FIREFOX_BUILD_DIR)
+
+# Lint for Chrome with web-ext
+lint-chrome:
+	$(WE) lint --source-dir=$(CHROME_BUILD_DIR)
+
+clean:
+	$(RM) $(BUILD_DIR)

--- a/src/manifest-chrome.json
+++ b/src/manifest-chrome.json
@@ -1,5 +1,3 @@
-// This is manifest for Chrome for development purposes.
-
 {
     "manifest_version": 3,
     "name": "Zendesk Link Collector",

--- a/src/manifest-chrome.json
+++ b/src/manifest-chrome.json
@@ -39,10 +39,5 @@
       ],
     "host_permissions": [
         "https://*.zendesk.com/*"
-    ],
-    "browser_specific_settings": {
-      "gecko": {
-        "id": "{e4a90df4-3bc1-11ee-be56-0242ac120002}"
-      }
-    }
+    ]
   }

--- a/src/manifest-firefox.json
+++ b/src/manifest-firefox.json
@@ -1,5 +1,3 @@
-// This is manifest for Chrome for development purposes.
-
 {
     "manifest_version": 3,
     "name": "Zendesk Link Collector",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -41,10 +41,5 @@
       ],
     "host_permissions": [
         "https://*.zendesk.com/*"
-    ],
-    "browser_specific_settings": {
-      "gecko": {
-        "id": "{e4a90df4-3bc1-11ee-be56-0242ac120002}"
-      }
-    }
+    ]
   }


### PR DESCRIPTION
- Split manifests for browsers.
- Each manifest now has 2 versions for each browser.
- A default manifest.json will remain in `src` for development purposes (chrome only).
- Introduce makefile to easily build for each browser. This copies the extension to a `build` subfolder and renames the brows-specific manifest file to `manifest.json`.

Resolves #19 