### PR TITLE
Add new "Images" tab for image attachment types

### DIFF
--- a/src/background/background.js
+++ b/src/background/background.js
@@ -110,16 +110,16 @@ async function filterTicket() {
     r++;
 
     //Grab only the required fields from the JSON.
-    await commentData.comments.forEach(async (comments) => {
+    await commentData.comments.forEach(async (comment) => {
       // Parse the HTML text and return an array of links.
-      const links = await parseAElementsFromHTMLText(comments.html_body);
+      const links = await parseAElementsFromHTMLText(comment.html_body);
       // Push the required link information to the linksArr.
       if (links.length > 0) {
         links.forEach((link) => {
           linksArr.push({
-            commentID: comments.id,
-            auditID: comments.audit_id,
-            createdAt: comments.created_at,
+            commentID: comment.id,
+            auditID: comment.audit_id,
+            createdAt: comment.created_at,
             parent_text: link.parent_text,
             text: link.text,
             href: link.href,
@@ -129,23 +129,32 @@ async function filterTicket() {
       }
 
       // Push the required attachment information to the attachmentsArr.
-      if (comments.attachments.length > 0) {
-        attachmentsArr.push({
-          commentID: comments.id,
-          auditID: comments.audit_id,
-          created_at: comments.created_at,
-          attachments: comments.attachments,
+      if (comment.attachments.length > 0) {
+        tempArr = [];
+        comment.attachments.forEach((attachment) => {
+          if (!attachment.content_type.startsWith("image/")) {
+            tempArr.push(attachment);
+          }
         });
+        if (tempArr.length > 0) {
+          attachmentsArr.push({
+            commentID: comment.id,
+            auditID: comment.audit_id,
+            created_at: comment.created_at,
+            attachments: tempArr,
+          });
+        }
       }
 
       // Filter images out of attachments data and push to imagesArr
-      comments.attachments.forEach((attachment) => {
+      comment.attachments.forEach((attachment) => {
         if (attachment.content_type.startsWith("image/")) {
           imagesArr.push({
-            commentID: comments.id,
-            auditID: comments.audit_id,
-            createdAt: comments.created_at,
+            commentID: comment.id,
+            auditID: comment.audit_id,
+            createdAt: comment.created_at,
             url: attachment.content_url,
+            mappedURL: attachment.mapped_content_url,
             fileName: attachment.file_name,
           });
         }

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -130,7 +130,7 @@ async function filterTicket() {
 
       // Push the required attachment information to the attachmentsArr.
       if (comment.attachments.length > 0) {
-        tempArr = [];
+        const tempArr = [];
         comment.attachments.forEach((attachment) => {
           if (!attachment.content_type.startsWith("image/")) {
             tempArr.push(attachment);

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -56,7 +56,7 @@ async function filterTicket() {
     ticketStorage: {
       links: [],
       attachments: [],
-      images: [], // Add images array to ticket data storage
+      images: [],
       state: "loading",
     },
   });

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -56,6 +56,7 @@ async function filterTicket() {
     ticketStorage: {
       links: [],
       attachments: [],
+      images: [], // Add images array to ticket data storage
       state: "loading",
     },
   });
@@ -81,6 +82,7 @@ async function filterTicket() {
   let numComments = 0; // Number of comments received from Zendesk.
   const linksArr = []; // Array of link objects to be displayed.
   const attachmentsArr = []; // Array of attachment objects to be displayed.
+  const imagesArr = []; // Array of image objects to be displayed.
 
   // Loop through all pages of comments until there are no more pages.
   while (nextPage != "" && r <= rlimit) {
@@ -135,6 +137,19 @@ async function filterTicket() {
           attachments: comments.attachments,
         });
       }
+
+      // Filter images out of attachments data and push to imagesArr
+      comments.attachments.forEach((attachment) => {
+        if (attachment.content_type.startsWith("image/")) {
+          imagesArr.push({
+            commentID: comments.id,
+            auditID: comments.audit_id,
+            createdAt: comments.created_at,
+            url: attachment.content_url,
+            fileName: attachment.file_name,
+          });
+        }
+      });
     });
   }
 
@@ -228,12 +243,14 @@ async function filterTicket() {
 
   console.log("filtered links: ", filteredLinks);
   console.log("attachments: ", attachmentsArr);
+  console.log("images: ", imagesArr); // Log the images array
 
-  // Store the filtered links and attachments for the current ticket in the browser storage.
+  // Store the filtered links, attachments, and images for the current ticket in the browser storage.
   browser.storage.local.set({
     ticketStorage: {
       links: filteredLinks,
       attachments: attachmentsArr,
+      images: imagesArr, // Store the images array
       state: "complete",
       count: numComments,
       ticketID: ticketID,

--- a/src/content-scripts/contentscript.js
+++ b/src/content-scripts/contentscript.js
@@ -1,72 +1,99 @@
 console.log("Zendesk Link Collector - loaded content script");
 
 // Message handler for messages from the background script.
-browser.runtime.onMessage.addListener(function(request, sender, sendResponse) {
+browser.runtime.onMessage.addListener(function (request, sender, sendResponse) {
   // Scroll to the comment.
   if (request.type == "scroll") {
-    const element = document.querySelector(`[data-comment-id="${request.commentID}"]`) 
-    // Older Zendesk versions.
-    ? document.querySelector(`[data-comment-id="${request.commentID}"]`)
-    // Newer Zendesk versions.
-    : document.querySelector(`[id="comment-${request.auditID}"]`);
+    const element = document.querySelector(
+      `[data-comment-id="${request.commentID}"]`
+    )
+      ? // Older Zendesk versions.
+        document.querySelector(`[data-comment-id="${request.commentID}"]`)
+      : // Newer Zendesk versions.
+        document.querySelector(`[id="comment-${request.auditID}"]`);
     if (element) {
       element.scrollIntoView({ behavior: "smooth", block: "center" });
       return;
     }
-    
+
     // Last resort, sometimes zendesk does not add the data-comment-id or id attributes to the comments.
     // Get the comment from the audits endpoint, find the comment with the same HTML in the DOM and scroll to it.
     const url = new URL(document.URL);
-    const urlArr = url.href.split('/');
+    const urlArr = url.href.split("/");
     const ticketID = urlArr[urlArr.length - 1];
-    
-    fetch(`${url.protocol}//${url.hostname}/api/v2/tickets/${ticketID}/audits/${request.auditID}`).then(async function(response) {
-    const data = await response.json();
-    document.querySelectorAll('.zd-comment').forEach((comment) => {
-      data.audit.events.forEach((event) => {
-        if (event.type == 'Comment') {
-          if (comment.outerHTML == event.html_body) {
-            comment.scrollIntoView({ behavior: "smooth", block: "center" });
-            return;
+
+    fetch(
+      `${url.protocol}//${url.hostname}/api/v2/tickets/${ticketID}/audits/${request.auditID}`
+    ).then(async function (response) {
+      const data = await response.json();
+      document.querySelectorAll(".zd-comment").forEach((comment) => {
+        data.audit.events.forEach((event) => {
+          if (event.type == "Comment") {
+            if (comment.outerHTML == event.html_body) {
+              comment.scrollIntoView({ behavior: "smooth", block: "center" });
+              return;
+            }
           }
-        }
+        });
       });
     });
-  });
-}
+  }
 
-// Code from https://stackoverflow.com/questions/55214828/how-to-make-a-cross-origin-request-in-a-content-script-currently-blocked-by-cor/55215898#55215898
-if (request.type == 'fetch') {
-  fetch(request.input, request.init).then(function(response) {
-    return response.text().then(function(text) {
-      sendResponse([{
-        body: text,
-        status: response.status,
-        statusText: response.statusText,
-      }, null]);
-    });
-  }, function(error) {
-    sendResponse([null, error]);
-  });
-}
-
-// Background script does not have a DOM, so when it needs to parse links from HTML, it sends this message. 
-if (request.type == 'parse-html-a') {
-  const parser = new DOMParser();
-  const doc = parser.parseFromString(request.htmlText, "text/html");
-  const links = doc.querySelectorAll(`a`);
-  const linksArr = [];
-  links.forEach((link) => {
-    linksArr.push(
-      {
-      parent_text: link.parentElement.innerHTML,
-      text: link.innerText,
-      href: link.href
+  // Code from https://stackoverflow.com/questions/55214828/how-to-make-a-cross-origin-request-in-a-content-script-currently-blocked-by-cor/55215898#55215898
+  if (request.type == "fetch") {
+    fetch(request.input, request.init).then(
+      function (response) {
+        return response.text().then(function (text) {
+          sendResponse([
+            {
+              body: text,
+              status: response.status,
+              statusText: response.statusText,
+            },
+            null,
+          ]);
+        });
+      },
+      function (error) {
+        sendResponse([null, error]);
       }
     );
-  });
-  sendResponse(linksArr);
-}
+  }
 
-return true;
+  // Background script does not have a DOM, so when it needs to parse links from HTML, it sends this message.
+  if (request.type == "parse-html-a") {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(request.htmlText, "text/html");
+    const links = doc.querySelectorAll(`a`);
+    const linksArr = [];
+    links.forEach((link) => {
+      linksArr.push({
+        parent_text: link.parentElement.innerHTML,
+        text: link.innerText,
+        href: link.href,
+      });
+    });
+    sendResponse(linksArr);
+  }
+
+  // Try to open zendesk preview.
+  if (request.type == "image-preview") {
+    const imageURL = request.imageURL;
+    document.querySelectorAll("a").forEach((a) => {
+      if (a.href == imageURL) {
+        //Close any modal that are open.
+        const closeButton = document.querySelector(
+          '[data-garden-id="modals.close"]'
+        );
+        if (closeButton) {
+          closeButton.click();
+        }
+        if (a) {
+          a.click();
+        }
+      }
+    });
+  }
+
+  return true;
 });

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -81,7 +81,7 @@ body {
     flex-direction: column;
     overflow: auto;
     min-width: 350px;
-    max-width: 500px;
+    max-width: 800px;
     min-height: 150px;
     max-height: 500px;
 }
@@ -220,18 +220,26 @@ h3.list-header {
 }
 
 /* Remove unused space between headers and the view buttons */
-#list-container-links h3:first-of-type, #list-container-attachments ul:first-of-type {
+#list-container-links h3:first-of-type, #list-container-attachments #list-container-images ul:first-of-type {
     margin-top: 0;
 }
 
-ul.list-links, ul.list-attachments {
+ul.list-links, ul.list-attachments, li.list-item-images {
     display: flex;
     flex-direction: column;
 }
 
-li.list-item-links, li.list-item-attachments {
+li.list-item-links, li.list-item-attachments, li.list-item-images {
     list-style: none;
     margin-bottom: 2px;
+}
+
+li.list-item-images {
+    margin-bottom: 30px;
+}
+
+li.list-item-images i {
+    margin-bottom: 7px;
 }
 
 li.list-item-links {
@@ -326,7 +334,19 @@ li.list-item-attachments ul li {
     flex-direction: column;
     padding: 20px;
     white-space: nowrap;
-    height: inherit;
+}
+
+.list-item-images {
+    margin-bottom: 30px;
+    max-width: 750px;
+}
+
+.list-item-images img {
+    max-width: 750px;
+}
+
+#list-container-images img:hover {
+    cursor: pointer;
 }
 
 #list-container-images.selected {

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -309,3 +309,26 @@ li.list-item-attachments ul li {
 .icon-search {
     background-image: url(../icons/search.svg);
 }
+
+/* New styles for the "Images" tab */
+.button-images.checked {
+    background-color: var(--accent);
+    border-color: var(--accent-dark);
+}
+
+.button-images.checked:hover {
+    background-color: var(--accent-hover);
+    border-color: var(--accent-dark-hover);
+}
+
+#list-container-images {
+    display: none;
+    flex-direction: column;
+    padding: 20px;
+    white-space: nowrap;
+    height: inherit;
+}
+
+#list-container-images.selected {
+    display: flex;
+}

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -8,6 +8,7 @@
     <div class="row" id="viewOption">
       <a href="#" class="button button-fill checked" id="button-links">Links</a>
       <a href="#" class="button button-fill" id="button-attachments">Attachments</a>
+      <a href="#" class="button button-fill" id="button-images">Images</a>
       <a href="#" class="button button-fill" id="button-options">
         <img class="icon icon-invert" src="../icons/gear.svg" width="15px" height="15px">
       </a>
@@ -40,6 +41,12 @@
       <div class="not-found-container hidden" id="not-found-container-attachments">
         <img src="../icons/bufo-sad-but-ok.png" width="50px" height="50px">
         <div>There doesn't seem to be any comments with attachments!</div>
+      </div>
+    </div>
+    <div id="list-container-images" class="list-container">
+      <div class="not-found-container hidden" id="not-found-container-images">
+        <img src="../icons/bufo-sad-but-ok.png" width="50px" height="50px">
+        <div>There doesn't seem to be any images!</div>
       </div>
     </div>
     <script type="application/javascript" src="../lib/browser-polyfill.min.js"></script>

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -517,4 +517,63 @@ document.addEventListener("DOMContentLoaded", () => {
         .getElementById("list-container-attachments")
         .classList.add("selected");
     });
+
+  // Add event listener for the new "Images" tab button to toggle the view
+  document.getElementById("button-images").addEventListener("click", () => {
+    document.getElementById("button-images").classList.add("checked");
+    document.getElementById("list-container-images").classList.add("selected");
+
+    // Deselect other tabs
+    document.getElementById("button-links").classList.remove("checked");
+    document.getElementById("list-container-links").classList.remove("selected");
+    document.getElementById("button-attachments").classList.remove("checked");
+    document
+      .getElementById("list-container-attachments")
+      .classList.remove("selected");
+
+    // Hide summary and background processing options for images tab
+    document.querySelectorAll(".row-links").forEach((row) => {
+      row.classList.remove("selected");
+    });
+  });
+
+  // Implement logic to populate the "Images" tab with image previews
+  async function displayImages(imagesArr) {
+    // If there are no images, display a message and return.
+    if (imagesArr.length <= 0) {
+      document
+        .getElementById("not-found-container-images")
+        .classList.remove("hidden");
+      return;
+    }
+    document.getElementById("not-found-container-images").classList.add("hidden");
+
+    // Get images container
+    const imagesList = document.getElementById("list-container-images");
+
+    // Clear the images container of previous content
+    imagesList.innerHTML = "";
+
+    // For each image, create an image element and append to the container
+    imagesArr.forEach((image) => {
+      const img = document.createElement("img");
+      img.src = image.url;
+      img.alt = image.fileName;
+      img.title = `Click to open in new tab\n\nFile: ${image.fileName}\nComment created at: ${image.createdAt}`;
+      img.style.maxWidth = "100%";
+      img.style.marginBottom = "10px";
+      img.addEventListener("click", () => {
+        // Implement functionality to open images in a new tab when clicked
+        window.open(image.url, '_blank').focus();
+      });
+      imagesList.appendChild(img);
+    });
+  }
+
+  // Use new image array in ticket data storage to populate the images tab data
+  browser.storage.local.get("ticketStorage").then((data) => {
+    if (data.ticketStorage && data.ticketStorage.images) {
+      displayImages(data.ticketStorage.images);
+    }
+  });
 });

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -535,6 +535,13 @@ document.addEventListener("DOMContentLoaded", () => {
     document.querySelectorAll(".row-links").forEach((row) => {
       row.classList.remove("selected");
     });
+
+    // Adjust the extension window size to 70% of the user's screen when the image tab is selected
+    if (window.screen.width) {
+      const newWidth = Math.floor(window.screen.width * 0.7);
+      const newHeight = Math.floor(window.screen.height * 0.7);
+      window.resizeTo(newWidth, newHeight);
+    }
   });
 
   // Implement logic to populate the "Images" tab with image previews


### PR DESCRIPTION
- Created a new "Images" tab to store image type attachments.
    - Image previews are shown in the "Image" instead of links.
    - Clicking on an image preview opens it in Zendesk's native image preview.
    - Scrolling to the image is possible, as usual.
- Removed image type files from the "Attachments" tab.

Closes #54 
Closes #9