### PR TITLE
Add "what's new?" button that links to release notes

### DIFF
--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -352,3 +352,19 @@ li.list-item-attachments ul li {
 #list-container-images.selected {
     display: flex;
 }
+
+/* New styles for the "What's new?" button */
+#button-whats-new {
+    background-color: var(--accent);
+    color: white;
+    padding: 5px 10px;
+    border-radius: 5px;
+    border: none;
+    text-align: center;
+    display: inline-block;
+    margin-left: auto;
+}
+
+#button-whats-new:hover {
+    background-color: var(--accent-hover);
+}

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -80,7 +80,7 @@ body {
 #container {
     flex-direction: column;
     overflow: auto;
-    min-width: 350px;
+    min-width: 450px;
     max-width: 800px;
     min-height: 150px;
     max-height: 500px;

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -154,6 +154,10 @@ a:hover {
     cursor: pointer;
 }
 
+#button-whats-new {
+    margin-left: auto;
+}
+
 .row {
     display: flex;
     flex-direction: row;
@@ -318,7 +322,6 @@ li.list-item-attachments ul li {
     background-image: url(../icons/search.svg);
 }
 
-/* New styles for the "Images" tab */
 .button-images.checked {
     background-color: var(--accent);
     border-color: var(--accent-dark);
@@ -351,20 +354,4 @@ li.list-item-attachments ul li {
 
 #list-container-images.selected {
     display: flex;
-}
-
-/* New styles for the "What's new?" button */
-#button-whats-new {
-    background-color: var(--accent);
-    color: white;
-    padding: 5px 10px;
-    border-radius: 5px;
-    border: none;
-    text-align: center;
-    display: inline-block;
-    margin-left: auto;
-}
-
-#button-whats-new:hover {
-    background-color: var(--accent-hover);
 }

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -12,6 +12,7 @@
       <a href="#" class="button button-fill" id="button-options">
         <img class="icon icon-invert" src="../icons/gear.svg" width="15px" height="15px">
       </a>
+      <a href="https://github.com/BagToad/Zendesk-Link-Collector/releases" class="button button-fill" id="button-whats-new" target="_blank">What's new?</a>
     </div>
     <div class="row row-links selected">
       <a href="#" title="Copy a configurable summary to clipboard in markdown. See the options page for configuration options." class="button button-sub" id="button-summary">

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -47,7 +47,7 @@
     <div id="list-container-images" class="list-container">
       <div class="not-found-container hidden" id="not-found-container-images">
         <img src="../icons/bufo-sad-but-ok.png" width="50px" height="50px">
-        <div>There doesn't seem to be any comments with images attachments!</div>
+        <div>There doesn't seem to be any comments with image attachments!</div>
       </div>
     </div>
     <script type="application/javascript" src="../lib/browser-polyfill.min.js"></script>

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -12,7 +12,6 @@
       <a href="#" class="button button-fill" id="button-options">
         <img class="icon icon-invert" src="../icons/gear.svg" width="15px" height="15px">
       </a>
-      <a href="https://github.com/BagToad/Zendesk-Link-Collector/releases" class="button button-fill" id="button-whats-new" target="_blank">What's new?</a>
     </div>
     <div class="row row-links selected">
       <a href="#" title="Copy a configurable summary to clipboard in markdown. See the options page for configuration options." class="button button-sub" id="button-summary">
@@ -28,6 +27,7 @@
         <img class="icon-button" id="refresh" src="../icons/loader.svg" width="15px" height="15px">
         <span for="refresh">Refresh</span>
       </a>
+      <a href="https://github.com/BagToad/Zendesk-Link-Collector/releases" class="button button-sub" id="button-whats-new" target="_blank">What's new?</a>
     </div>
     <div id="container" style="display: flex">
     <div id="loader" class="loading"></div>

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -47,7 +47,7 @@
     <div id="list-container-images" class="list-container">
       <div class="not-found-container hidden" id="not-found-container-images">
         <img src="../icons/bufo-sad-but-ok.png" width="50px" height="50px">
-        <div>There doesn't seem to be any images!</div>
+        <div>There doesn't seem to be any comments with images attachments!</div>
       </div>
     </div>
     <script type="application/javascript" src="../lib/browser-polyfill.min.js"></script>


### PR DESCRIPTION
This pull request primarily focuses on improving the user interface and user experience of the application.

In addition to the new button, there are some other minor UI changes:

- Increasing the minimum width of the container
- Updating the message displayed when no images are found
- Removing a comment in the CSS file. 

![image](https://github.com/BagToad/Zendesk-Link-Collector/assets/47394200/53f5faaf-6680-4f41-9308-68cbe3e87d98)

Closes #36 
