### PR TITLE
Add keyboard shortcuts to copy ticket ID and copy ticket link in markdown

### DIFF
--- a/src/background/background.js
+++ b/src/background/background.js
@@ -446,4 +446,21 @@ browser.runtime.onMessage.addListener((message) => {
   }
 });
 
+// Listen for keyboard shortcuts
+browser.commands.onCommand.addListener((command) => {
+  switch (command) {
+    case "copy-ticket-id":
+      // Logic to copy the ticket ID to the clipboard
+      break;
+    case "open-ui":
+      // Logic to open the extension UI
+      break;
+    case "open-attachments":
+      // Logic to navigate to the attachments tab within the extension UI
+      break;
+    default:
+      console.log(`Command ${command} not recognized.`);
+  }
+});
+
 // TODO: Listen for ticket changed messages from the content script

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -450,13 +450,46 @@ browser.runtime.onMessage.addListener((message) => {
 browser.commands.onCommand.addListener((command) => {
   switch (command) {
     case "copy-ticket-id":
-      // Logic to copy the ticket ID to the clipboard
+      // Logic to send a message to the contentscript to copy the ticket ID to the clipboard.
+      // If background processing is disabled, send a message to the contentscript to indicate that copying is not possible.
+      isBackgroundProcessingEnabled().then((status) => {
+        if (!status) {
+          browser.tabs
+            .query({ active: true, currentWindow: true })
+            .then((tabs) => {
+              browser.tabs.sendMessage(tabs[0].id, {
+                type: "copy-not-possible",
+              });
+            });
+          return;
+        }
+        browser.tabs
+          .query({ active: true, currentWindow: true })
+          .then((tabs) => {
+            browser.tabs.sendMessage(tabs[0].id, { type: "copy-ticket-id" });
+          });
+      });
       break;
-    case "open-ui":
-      // Logic to open the extension UI
-      break;
-    case "open-attachments":
-      // Logic to navigate to the attachments tab within the extension UI
+    case "copy-ticket-id-md":
+      // Logic to send a message to the contentscript to copy the ticket ID to the clipboard in markdown.
+      // If background processing is disabled, send a message to the contentscript to indicate that copying is not possible.
+      isBackgroundProcessingEnabled().then((status) => {
+        if (!status) {
+          browser.tabs
+            .query({ active: true, currentWindow: true })
+            .then((tabs) => {
+              browser.tabs.sendMessage(tabs[0].id, {
+                type: "copy-not-possible",
+              });
+            });
+          return;
+        }
+        browser.tabs
+          .query({ active: true, currentWindow: true })
+          .then((tabs) => {
+            browser.tabs.sendMessage(tabs[0].id, { type: "copy-ticket-id-md" });
+          });
+      });
       break;
     default:
       console.log(`Command ${command} not recognized.`);

--- a/src/content-scripts/contentscript.js
+++ b/src/content-scripts/contentscript.js
@@ -95,5 +95,38 @@ browser.runtime.onMessage.addListener(function (request, sender, sendResponse) {
     });
   }
 
+  // Copying to clipboard not possible
+  if (request.type == "copy-not-possible") {
+    navigator.clipboard.writeText("ZLC - Background processing disabled.");
+  }
+
+  // Copy ticket ID to clipboard.
+  if (request.type == "copy-ticket-id") {
+    browser.storage.local.get("ticketStorage").then((data) => {
+      if (
+        data.ticketStorage == undefined ||
+        data.ticketStorage.ticketID == undefined
+      ) {
+        return;
+      }
+      navigator.clipboard.writeText(data.ticketStorage.ticketID);
+    });
+  }
+
+  // Copy ticket ID to clipboard in markdown.
+  if (request.type == "copy-ticket-id-md") {
+    browser.storage.local.get("ticketStorage").then((data) => {
+      if (
+        data.ticketStorage == undefined ||
+        data.ticketStorage.ticketID == undefined
+      ) {
+        return;
+      }
+      navigator.clipboard.writeText(
+        `[ZD#${data.ticketStorage.ticketID}](${document.URL})`
+      );
+    });
+  }
+
   return true;
 });

--- a/src/manifest-chrome.json
+++ b/src/manifest-chrome.json
@@ -33,14 +33,35 @@
   "commands": {
     "_execute_action": {
       "description": "Open the extension"
+    },
+    "copy-ticket-id": {
+      "suggested_key": {
+        "default": "Alt+C",
+        "mac": "Command+C"
+      },
+      "description": "Copy ticket ID to clipboard"
+    },
+    "open-ui": {
+      "suggested_key": {
+        "default": "Alt+U",
+        "mac": "Command+U"
+      },
+      "description": "Open extension UI"
+    },
+    "open-attachments": {
+      "suggested_key": {
+        "default": "Alt+A",
+        "mac": "Command+A"
+      },
+      "description": "Navigate to attachments tab"
     }
   },
-    "permissions": [
-      "activeTab",
-      "storage",
-      "clipboardWrite"
-    ],
+  "permissions": [
+    "activeTab",
+    "storage",
+    "clipboardWrite"
+  ],
   "host_permissions": [
-      "https://*.zendesk.com/*"
+    "https://*.zendesk.com/*"
   ]
 }

--- a/src/manifest-chrome.json
+++ b/src/manifest-chrome.json
@@ -10,10 +10,7 @@
     {
       "matches": ["https://*.zendesk.com/*"],
       "run_at": "document_start",
-      "js": [
-        "lib/browser-polyfill.min.js",
-        "content-scripts/contentscript.js"
-      ]
+      "js": ["lib/browser-polyfill.min.js", "content-scripts/contentscript.js"]
     }
   ],
   "icons": {
@@ -28,40 +25,19 @@
     "open_in_tab": true
   },
   "action": {
-      "default_popup": "popup/popup.html"
-    },
+    "default_popup": "popup/popup.html"
+  },
   "commands": {
     "_execute_action": {
       "description": "Open the extension"
     },
     "copy-ticket-id": {
-      "suggested_key": {
-        "default": "Alt+C",
-        "mac": "Command+C"
-      },
       "description": "Copy ticket ID to clipboard"
     },
-    "open-ui": {
-      "suggested_key": {
-        "default": "Alt+U",
-        "mac": "Command+U"
-      },
-      "description": "Open extension UI"
-    },
-    "open-attachments": {
-      "suggested_key": {
-        "default": "Alt+A",
-        "mac": "Command+A"
-      },
-      "description": "Navigate to attachments tab"
+    "copy-ticket-id-md": {
+      "description": "Copy ticket ID to clipboard in markdown"
     }
   },
-  "permissions": [
-    "activeTab",
-    "storage",
-    "clipboardWrite"
-  ],
-  "host_permissions": [
-    "https://*.zendesk.com/*"
-  ]
+  "permissions": ["activeTab", "storage", "clipboardWrite"],
+  "host_permissions": ["https://*.zendesk.com/*"]
 }

--- a/src/manifest-firefox.json
+++ b/src/manifest-firefox.json
@@ -33,6 +33,27 @@
   "commands": {
     "_execute_action": {
       "description": "Open the extension"
+    },
+    "copy-ticket-id": {
+      "suggested_key": {
+        "default": "Alt+C",
+        "mac": "Command+C"
+      },
+      "description": "Copy ticket ID to clipboard"
+    },
+    "open-ui": {
+      "suggested_key": {
+        "default": "Alt+U",
+        "mac": "Command+U"
+      },
+      "description": "Open extension UI"
+    },
+    "open-attachments": {
+      "suggested_key": {
+        "default": "Alt+A",
+        "mac": "Command+A"
+      },
+      "description": "Navigate to attachments tab"
     }
   },
     "permissions": [

--- a/src/manifest-firefox.json
+++ b/src/manifest-firefox.json
@@ -4,16 +4,13 @@
   "version": "1.2.0",
   "description": "Summarize links and attachments",
   "background": {
-    "scripts": ["lib/browser-polyfill.min.js","background/background.js"]
+    "scripts": ["lib/browser-polyfill.min.js", "background/background.js"]
   },
   "content_scripts": [
     {
       "matches": ["https://*.zendesk.com/*"],
       "run_at": "document_start",
-      "js": [
-        "lib/browser-polyfill.min.js",
-        "content-scripts/contentscript.js"
-      ]
+      "js": ["lib/browser-polyfill.min.js", "content-scripts/contentscript.js"]
     }
   ],
   "icons": {
@@ -28,42 +25,21 @@
     "open_in_tab": true
   },
   "action": {
-      "default_popup": "popup/popup.html"
-    },
+    "default_popup": "popup/popup.html"
+  },
   "commands": {
     "_execute_action": {
       "description": "Open the extension"
     },
     "copy-ticket-id": {
-      "suggested_key": {
-        "default": "Alt+C",
-        "mac": "Command+C"
-      },
       "description": "Copy ticket ID to clipboard"
     },
-    "open-ui": {
-      "suggested_key": {
-        "default": "Alt+U",
-        "mac": "Command+U"
-      },
-      "description": "Open extension UI"
-    },
-    "open-attachments": {
-      "suggested_key": {
-        "default": "Alt+A",
-        "mac": "Command+A"
-      },
-      "description": "Navigate to attachments tab"
+    "copy-ticket-id-md": {
+      "description": "Copy ticket ID to clipboard in markdown"
     }
   },
-    "permissions": [
-      "activeTab",
-      "storage",
-      "clipboardWrite"
-    ],
-  "host_permissions": [
-      "https://*.zendesk.com/*"
-  ],
+  "permissions": ["activeTab", "storage", "clipboardWrite"],
+  "host_permissions": ["https://*.zendesk.com/*"],
   "browser_specific_settings": {
     "gecko": {
       "id": "{e4a90df4-3bc1-11ee-be56-0242ac120002}"

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,5 +1,3 @@
-// This is manifest for Chrome for development purposes.
-
 {
     "manifest_version": 3,
     "name": "Zendesk Link Collector",
@@ -35,14 +33,35 @@
     "commands": {
       "_execute_action": {
         "description": "Open the extension"
+      },
+      "copy-ticket-id": {
+        "suggested_key": {
+          "default": "Alt+C",
+          "mac": "Command+C"
+        },
+        "description": "Copy ticket ID to clipboard"
+      },
+      "open-ui": {
+        "suggested_key": {
+          "default": "Alt+U",
+          "mac": "Command+U"
+        },
+        "description": "Open extension UI"
+      },
+      "open-attachments": {
+        "suggested_key": {
+          "default": "Alt+A",
+          "mac": "Command+A"
+        },
+        "description": "Navigate to attachments tab"
       }
     },
-      "permissions": [
-        "activeTab",
-        "storage",
-        "clipboardWrite"
-      ],
+    "permissions": [
+      "activeTab",
+      "storage",
+      "clipboardWrite"
+    ],
     "host_permissions": [
-        "https://*.zendesk.com/*"
+      "https://*.zendesk.com/*"
     ]
-  }
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,67 +1,43 @@
 {
-    "manifest_version": 3,
-    "name": "Zendesk Link Collector",
-    "version": "1.2.0",
-    "description": "Summarize links and attachments",
-    "background": {
-      "service_worker": "background/background.js"
+  "manifest_version": 3,
+  "name": "Zendesk Link Collector",
+  "version": "1.2.0",
+  "description": "Summarize links and attachments",
+  "background": {
+    "service_worker": "background/background.js"
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://*.zendesk.com/*"],
+      "run_at": "document_start",
+      "js": ["lib/browser-polyfill.min.js", "content-scripts/contentscript.js"]
+    }
+  ],
+  "icons": {
+    "128": "icons/zlc-icon-128x128.png",
+    "48": "icons/zlc-icon-48x48.png",
+    "32": "icons/zlc-icon-32x32.png",
+    "16": "icons/zlc-icon-16x16.png"
+  },
+  "options_ui": {
+    "page": "options/options.html",
+    "browser_style": false,
+    "open_in_tab": true
+  },
+  "action": {
+    "default_popup": "popup/popup.html"
+  },
+  "commands": {
+    "_execute_action": {
+      "description": "Open the extension"
     },
-    "content_scripts": [
-      {
-        "matches": ["https://*.zendesk.com/*"],
-        "run_at": "document_start",
-        "js": [
-          "lib/browser-polyfill.min.js",
-          "content-scripts/contentscript.js"
-        ]
-      }
-    ],
-    "icons": {
-      "128": "icons/zlc-icon-128x128.png",
-      "48": "icons/zlc-icon-48x48.png",
-      "32": "icons/zlc-icon-32x32.png",
-      "16": "icons/zlc-icon-16x16.png"
+    "copy-ticket-id": {
+      "description": "Copy ticket ID to clipboard"
     },
-    "options_ui": {
-      "page": "options/options.html",
-      "browser_style": false,
-      "open_in_tab": true
-    },
-    "action": {
-        "default_popup": "popup/popup.html"
-      },
-    "commands": {
-      "_execute_action": {
-        "description": "Open the extension"
-      },
-      "copy-ticket-id": {
-        "suggested_key": {
-          "default": "Alt+C",
-          "mac": "Command+C"
-        },
-        "description": "Copy ticket ID to clipboard"
-      },
-      "open-ui": {
-        "suggested_key": {
-          "default": "Alt+U",
-          "mac": "Command+U"
-        },
-        "description": "Open extension UI"
-      },
-      "open-attachments": {
-        "suggested_key": {
-          "default": "Alt+A",
-          "mac": "Command+A"
-        },
-        "description": "Navigate to attachments tab"
-      }
-    },
-    "permissions": [
-      "activeTab",
-      "storage",
-      "clipboardWrite"
-    ],
-    "host_permissions": [
-      "https://*.zendesk.com/*"
-    ]
+    "copy-ticket-id-md": {
+      "description": "Copy ticket ID to clipboard in markdown"
+    }
+  },
+  "permissions": ["activeTab", "storage", "clipboardWrite"],
+  "host_permissions": ["https://*.zendesk.com/*"]
 }


### PR DESCRIPTION
This pull request adds support for new keyboard shortcuts for copying ticket IDs: 

- Copy ticket ID to clipboard
- Copy ticket link in markdown to clipboard

These changes are primarily in the `src/background/background.js` and `src/content-scripts/contentscript.js` files, but also include updates to the manifest files for Chrome, Firefox, and a generic manifest file.