### PR TITLE
Display version number instead of "What's new?" text. 

### DIFF
--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -27,7 +27,7 @@
         <img class="icon-button" id="refresh" src="../icons/loader.svg" width="15px" height="15px">
         <span for="refresh">Refresh</span>
       </a>
-      <a href="#" class="button button-sub" id="button-whats-new"></a>
+      <a href="#" class="button button-sub" id="button-whats-new" target="_blank"></a>
     </div>
     <div id="container" style="display: flex">
     <div id="loader" class="loading"></div>

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -27,7 +27,7 @@
         <img class="icon-button" id="refresh" src="../icons/loader.svg" width="15px" height="15px">
         <span for="refresh">Refresh</span>
       </a>
-      <a href="https://github.com/BagToad/Zendesk-Link-Collector/releases" class="button button-sub" id="button-whats-new" target="_blank">What's new?</a>
+      <a href="#" class="button button-sub" id="button-whats-new"></a>
     </div>
     <div id="container" style="display: flex">
     <div id="loader" class="loading"></div>

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -626,5 +626,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Dynamically retrieve the version number from manifest.json and insert it into the "What's new?" button text.
   const manifestData = browser.runtime.getManifest();
-  document.getElementById("button-whats-new").textContent = `Version: ${manifestData.version}`;
+  document.getElementById(
+    "button-whats-new"
+  ).textContent = `v${manifestData.version}`;
 });

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -623,4 +623,8 @@ document.addEventListener("DOMContentLoaded", () => {
       row.classList.remove("selected");
     });
   });
+
+  // Dynamically retrieve the version number from manifest.json and insert it into the "What's new?" button text.
+  const manifestData = browser.runtime.getManifest();
+  document.getElementById("button-whats-new").textContent = `Version: ${manifestData.version}`;
 });

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -626,7 +626,11 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Dynamically retrieve the version number from manifest.json and insert it into the "What's new?" button text.
   const manifestData = browser.runtime.getManifest();
-  document.getElementById(
-    "button-whats-new"
-  ).textContent = `v${manifestData.version}`;
+  const version = manifestData.version;
+  const whatsNewButton = document.getElementById("button-whats-new");
+  whatsNewButton.textContent = `v${version}`;
+  whatsNewButton.setAttribute(
+    "href",
+    `https://github.com/bagtoad/zendesk-link-collector/releases/tag/v${version}`
+  );
 });


### PR DESCRIPTION
Display version number instead of "What's new?" text and link to the specific release notes for the installed version instead of just a hard-coded link to the latest. 

![image](https://github.com/BagToad/Zendesk-Link-Collector/assets/47394200/71df8707-f799-45cc-a3d8-b6f2e6e0ef01)


Closes #58 