### PR TITLE
Replace var declarations with let or const

### DIFF
--- a/src/background/background.js
+++ b/src/background/background.js
@@ -273,10 +273,10 @@ async function filterTicket() {
 // Return -1 if version1 is less than version2.
 // Return 0 if version1 is equal to version2.
 function compareVersions(version1, version2) {
-  var v1parts = version1.split(".");
-  var v2parts = version2.split(".");
+  const v1parts = version1.split(".");
+  const v2parts = version2.split(".");
 
-  for (var i = 0; i < v1parts.length; ++i) {
+  for (let i = 0; i < v1parts.length; ++i) {
     if (v2parts.length === i) {
       return 1;
     }


### PR DESCRIPTION
This change replaces the use of var declarations with let or const, ensuring better scoping and immutability respectively, which leads to cleaner, more predictable code and helps prevent unintended variable reassignments or scope leaks.

Closes: #60 