### PR TITLE
Add option to include date in links

### DIFF
--- a/src/background/background.js
+++ b/src/background/background.js
@@ -219,9 +219,12 @@ async function filterTicket() {
     linksArr.forEach((link) => {
       const re = new RegExp(filter.pattern);
       if (re.test(link.href)) {
-        link.summaryType =
+        link2Push = Object.assign({}, link);
+        link2Push.summaryType =
           filter.summaryType === undefined ? "all" : filter.summaryType;
-        filteredLinksArr.push(link);
+        link2Push.showDate =
+          filter.showDate === undefined ? false : filter.showDate;
+        filteredLinksArr.push(link2Push);
       }
     });
 

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -253,6 +253,43 @@ async function filterTicket() {
     }
   });
 
+  // Alternative implementation of the previous algorithm for future thought:
+  /*
+const filteredLinks = filters.flatMap((filter) => {
+  const re = new RegExp(filter.pattern);
+  const filteredLinksArr = linksArr
+    .filter((link) => re.test(link.href))
+    .map((link) => {
+      return {
+        ...link,
+        summaryType: filter.summaryType === undefined ? "all" : filter.summaryType,
+        showDate: filter.showDate === undefined ? false : filter.showDate,
+      };
+    });
+
+  const filteredLinksArrUnique = filteredLinksArr.reduce((unique, link) => {
+    const found = unique.find((l) => l.href == link.href);
+    if (!found) {
+      return [...unique, link];
+    } else if (link.createdAt > found.createdAt && found.createdAt != null) {
+      return [...unique.filter((l) => l.href !== link.href), link];
+    } else {
+      return unique;
+    }
+  }, []);
+
+  if (filteredLinksArrUnique.length > 0) {
+    return {
+      title: filter.title,
+      showParent: filter.showParent,
+      links: filteredLinksArrUnique,
+    };
+  } else {
+    return [];
+  }
+});
+*/
+
   console.log("filtered links: ", filteredLinks);
   console.log("attachments: ", attachmentsArr);
   console.log("images: ", imagesArr); // Log the images array

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -219,7 +219,7 @@ async function filterTicket() {
     linksArr.forEach((link) => {
       const re = new RegExp(filter.pattern);
       if (re.test(link.href)) {
-        link2Push = Object.assign({}, link);
+        const link2Push = Object.assign({}, link);
         link2Push.summaryType =
           filter.summaryType === undefined ? "all" : filter.summaryType;
         link2Push.showDate =

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -31,6 +31,8 @@
                 <option value="latest">Latest</option>
                 <option value="all">All</option>
             </select>
+            <label class="input-label" title="Show the comment date where the link was found." for="show-date">Show Date:</label>
+            <input type="checkbox" id="show-date">
             <button id="button-save-link-patterns">Save Link Pattern</button>
         </div>
         <div id="container-link-patterns-error" class="input-container-row">
@@ -43,6 +45,7 @@
                 <th>Pattern</th>
                 <th>Show Context</th>
                 <th>Summary Type</th>
+                <th>Show Date</th>
                 <th>Delete</th>
                 <th>Reorder</th>
             </tr>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -56,6 +56,15 @@ function loadLinkPatterns() {
       }
       nodes.push(tdSummaryType);
 
+      // Create show parent cell.
+      const tdDate = document.createElement("td");
+      const checkboxDate = document.createElement("input");
+      checkboxDate.setAttribute("type", "checkbox");
+      checkboxDate.setAttribute("disabled", "true");
+      checkboxDate.checked = option.showDate;
+      tdDate.appendChild(checkboxDate);
+      nodes.push(tdDate);
+
       // Create delete cell.
       const tdDelete = document.createElement("td");
       const buttonDelete = document.createElement("button");
@@ -144,6 +153,7 @@ function saveLinkPatterns() {
       pattern: document.getElementById("pattern").value,
       showParent: document.getElementById("show-parent").checked,
       summaryType: document.getElementById("summary-type").value,
+      showDate: document.getElementById("show-date").checked,
     });
     // Save new link pattern to disk.
     browser.storage.sync.set({ options: data.options }).then(() => {
@@ -154,6 +164,7 @@ function saveLinkPatterns() {
       document.getElementById("pattern").value = "";
       document.getElementById("show-parent").checked = false;
       document.getElementById("summary-type").value = "none";
+      document.getElementById("show-date").checked = false;
     });
   });
 }

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -361,7 +361,7 @@ li.list-item-attachments ul li {
 }
 
 #list-container-images img:hover {
-    cursor: pointer;
+    cursor: zoom-in;
 }
 
 #list-container-images.selected {

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -269,6 +269,7 @@ li .link-date {
 li .link-date:hover {
     cursor: pointer;
     font-size: 1em;
+    text-decoration: underline;
 }
 
 li.list-item-attachments ul li {

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -252,11 +252,23 @@ li.list-item-links {
 }
 
 /* Force context to shrink first before shrinking the link text. */
-li.list-item-links .link-context {
+/* li.list-item-links .link-context {
     flex-shrink: 0;
     flex-grow: 1;
     flex-basis: 0px;
     min-width: 0px;
+} */
+
+li .link-date {
+    color: var(--accent-light);
+    font-size: 0.80em;
+    display: flex;
+    align-items: center; /* This will align the item vertically */
+}
+
+li .link-date:hover {
+    cursor: pointer;
+    font-size: 1em;
 }
 
 li.list-item-attachments ul li {

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -210,6 +210,34 @@ async function displayLinks(linksBundle) {
         a.textContent = link.text;
         li.appendChild(a);
       }
+
+      if (link.showDate) {
+        // Append the date to the list item.
+        const spanDate = document.createElement("span");
+        const spaceNode = document.createTextNode(" ");
+        spanDate.setAttribute("class", "link-date");
+        const date = new Date(link.createdAt);
+        const year = date.getFullYear().toString().slice(-2);
+        const time = date.toLocaleTimeString("en-US", {
+          hour: "2-digit",
+          minute: "2-digit",
+          hour12: true,
+        });
+
+        spanDate.textContent = `\u00A0- ${date.toLocaleString("en-US", {
+          month: "short",
+        })} ${date.getDate()}, '${year} at ${time}`;
+        spanDate.setAttribute(
+          "title",
+          `Click to copy time in UTC\n\n${link.createdAt}`
+        );
+        li.appendChild(spaceNode);
+        li.appendChild(spanDate);
+        spanDate.addEventListener("click", () => {
+          navigator.clipboard.writeText(link.createdAt);
+        });
+      }
+
       ul.appendChild(li);
     });
 


### PR DESCRIPTION
This PR adds an option under each link pattern to display the source comment's date beside the link in the extension popup.

Closes #51 

![image](https://github.com/BagToad/Zendesk-Link-Collector/assets/47394200/60227aa0-55c4-43c3-b191-08e6e4a965d3)

### Changes

- Clicking the date text will copy the date to the clipboard in UTC. 
- The cursor hover image is now a zoom icon for images in the images tab. 
- This PR also fixes a bug where Summary Type and Show Dates options would be incorrectly overwritten for identical filter patterns.

### Technical Details

Functional enhancements:

* [`src/background/background.js`](diffhunk://#diff-d7072b9c615837a7b1318ff38a6dda1ea436aeb0b8fc073d1b32e52b73378937L222-R227): Modified the `filterTicket()` function to create a new object `link2Push` from the current `link` object and added `summaryType` and `showDate` properties to `link2Push` before pushing it to `filteredLinksArr`. This change enhances the filtering process by providing more context about the links.

New features:

* [`src/options/options.html`](diffhunk://#diff-594c44a28df5453d166af1cfc08191e04d1a2576a04161c773b2ea80e2dac86cR34-R35): Added a new checkbox input field with the label "Show Date" in the saved link patterns section. This allows users to decide whether to display the date of comments where links were found.
* [`src/options/options.js`](diffhunk://#diff-481db4dd012a189e3c3b4376cd1b6a484232afa7c73a8ef4d9ea1b476c720439R59-R67): Updated the `loadLinkPatterns()` and `saveLinkPatterns()` functions to handle the new "Show Date" option. This ensures that the user's preference for displaying dates is saved and loaded correctly. [[1]](diffhunk://#diff-481db4dd012a189e3c3b4376cd1b6a484232afa7c73a8ef4d9ea1b476c720439R59-R67) [[2]](diffhunk://#diff-481db4dd012a189e3c3b4376cd1b6a484232afa7c73a8ef4d9ea1b476c720439R156) [[3]](diffhunk://#diff-481db4dd012a189e3c3b4376cd1b6a484232afa7c73a8ef4d9ea1b476c720439R167)

UI Changes:

* [`src/popup/popup.css`](diffhunk://#diff-84de4f7ad44fd62f01b23dde0a7a309d1bf17f94384c2708f548552558cce330L255-R271): Added CSS rules for the new `link-date` class, which is used to style the date display in the link list.
* [`src/popup/popup.js`](diffhunk://#diff-ab496aae826a192f9749a1e1587333b332665bd90e6e6d5a969cfba69e5f6f34R213-R240): Updated the `displayLinks()` function to append a date span to the list item if the `showDate` property of a link is true. This change ensures that the date is displayed next to the link in the popup if the user has opted to show dates.

Commented code:

* [`src/background/background.js`](diffhunk://#diff-d7072b9c615837a7b1318ff38a6dda1ea436aeb0b8fc073d1b32e52b73378937R256-R292): Commented out an alternative implementation of the filtering algorithm for future consideration.