### PR TITLE
Feature: in-place link pattern editing

### DIFF
--- a/src/background/background.js
+++ b/src/background/background.js
@@ -464,21 +464,6 @@ browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
   browser.action.enable(tab.id);
 });
 
-// Monitor settings changes in the options storage, then reprocess the ticket.
-browser.storage.onChanged.addListener((changed) => {
-  // If the options have not changed, return.
-  if (!changed.options) {
-    return;
-  }
-
-  // If the link patterns have changed, reprocess the ticket.
-  isBackgroundProcessingEnabled().then((status) => {
-    if (status) {
-      filterTicket();
-    }
-  });
-});
-
 // Listen for messages from the popup
 browser.runtime.onMessage.addListener((message) => {
   if (message.type == "refresh") {

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -25,6 +25,15 @@ button {
     color: rgb(201, 209, 217);
 }
 
+button:disabled {
+    background-color: rgb(39, 44, 51);
+    color: rgb(148 147 147);
+}
+
+button:disabled:hover {
+    cursor: not-allowed;
+}
+
 .input-label {
     position: relative;
   }
@@ -105,4 +114,8 @@ table#table-link-patterns th {
     font-size: 15px;
     background-color: rgb(32, 37, 45);
     padding: 10px;
+}
+
+table tr.editing {
+    background-color: rgb(179 0 0 / 18%);
 }

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -46,6 +46,7 @@
                 <th>Show Context</th>
                 <th>Summary Type</th>
                 <th>Show Date</th>
+                <th>Edit</th>
                 <th>Delete</th>
                 <th>Reorder</th>
             </tr>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -120,7 +120,6 @@ function setLinkPatternError(err) {
   document.getElementById("link-patterns-error").textContent = err;
   if (err != "" && err != undefined) {
     document.getElementById("link-patterns-error").classList.remove("hidden");
-    console.log("here");
     return;
   }
   document.getElementById("link-patterns-error").classList.add("hidden");


### PR DESCRIPTION
This pull request adds the ability to edit existing link patterns in the options page. 

Closes #50 

![image](https://github.com/BagToad/Zendesk-Link-Collector/assets/47394200/d1447d63-cf27-4222-95c2-ec83119fc7a9)

## Technical Details

User Interface Changes:

* [`src/options/options.css`](diffhunk://#diff-0f6ed38497050661f6aaf383e9697bc64c4423c1828830f2a1c2d2cce7d89d6fR28-R36): Added styles for disabled buttons and rows being edited in the link patterns table. [[1]](diffhunk://#diff-0f6ed38497050661f6aaf383e9697bc64c4423c1828830f2a1c2d2cce7d89d6fR28-R36) [[2]](diffhunk://#diff-0f6ed38497050661f6aaf383e9697bc64c4423c1828830f2a1c2d2cce7d89d6fR118-R121)
* [`src/options/options.html`](diffhunk://#diff-594c44a28df5453d166af1cfc08191e04d1a2576a04161c773b2ea80e2dac86cR49): Added a new column in the link patterns table for the 'Edit' action.

JavaScript Functionality Changes:

* [`src/options/options.js`](diffhunk://#diff-481db4dd012a189e3c3b4376cd1b6a484232afa7c73a8ef4d9ea1b476c720439R68-R79): Added the ability to edit link patterns. This includes creating an 'Edit' button for each row in the link patterns table, disabling all buttons when a row is being edited, filling the input fields with the current values of the selected link pattern, changing the 'Save' button to an 'Update' button, and updating the link pattern with the new values from the input fields. [[1]](diffhunk://#diff-481db4dd012a189e3c3b4376cd1b6a484232afa7c73a8ef4d9ea1b476c720439R68-R79) [[2]](diffhunk://#diff-481db4dd012a189e3c3b4376cd1b6a484232afa7c73a8ef4d9ea1b476c720439L97-R106) [[3]](diffhunk://#diff-481db4dd012a189e3c3b4376cd1b6a484232afa7c73a8ef4d9ea1b476c720439R236-R338) [[4]](diffhunk://#diff-481db4dd012a189e3c3b4376cd1b6a484232afa7c73a8ef4d9ea1b476c720439L345-R474)

Background Script Changes:

* [`src/background/background.js`](diffhunk://#diff-d7072b9c615837a7b1318ff38a6dda1ea436aeb0b8fc073d1b32e52b73378937L467-L481): Removed the listener for storage changes. This was previously used to reprocess the ticket when the link patterns changed, but is actually not needed. It was causing tickets to be reloaded while on the options page, but that always ended up with an error. 