### PR TITLE
Add buttons to copy attachments and images to clipboard in markdown format

### DIFF
--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -164,11 +164,15 @@ a:hover {
     width: 100%;
 }
 
-.row-links {
+.row-sub {
     display: none;
 }
 
-.row-links.selected {
+/* .row-links {
+    display: none;
+} */
+
+.row-sub.selected {
     display: flex;
 }
 

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -13,7 +13,7 @@
         <img class="icon icon-invert" src="../icons/gear.svg" width="15px" height="15px">
       </a>
     </div>
-    <div class="row row-links selected">
+    <div class="row row-sub row-links selected">
       <a href="#" title="Copy a configurable summary to clipboard in markdown. See the options page for configuration options." class="button button-sub" id="button-summary">
         <img class="icon-button hidden" id="summary-check" src="../icons/check.svg" width="15px" height="15px">
         <img class="icon-button icon-invert" id="summary-copy" src="../icons/copy.svg" width="15px" height="15px">
@@ -29,6 +29,20 @@
       </a>
       <a href="#" class="button button-sub" id="button-whats-new" target="_blank"></a>
     </div>
+    <div class="row row-sub row-attachments">
+      <a href="#" class="button button-sub" id="button-copy-attachments-md">
+        <img class="icon-button hidden" id="attachments-check" src="../icons/check.svg" width="15px" height="15px">
+        <img class="icon-button icon-invert" id="attachments-copy" src="../icons/copy.svg" width="15px" height="15px">
+        <span id="attachments-text">Attachments</span>
+      </a>
+    </div>
+    <div class="row row-sub row-images">
+      <a href="#" class="button button-sub" id="button-copy-images-md">
+        <img class="icon-button hidden" id="images-check" src="../icons/check.svg" width="15px" height="15px">
+        <img class="icon-button icon-invert" id="images-copy" src="../icons/copy.svg" width="15px" height="15px">
+        <span id="images-text">Images</span>
+      </a>
+    </div>
     <div id="container" style="display: flex">
     <div id="loader" class="loading"></div>
     <div id="list-container-links" class="list-container selected">
@@ -43,14 +57,12 @@
         <img src="../icons/bufo-sad-but-ok.png" width="50px" height="50px">
         <div>There doesn't seem to be any comments with attachments!</div>
       </div>
-      <a href="#" class="button button-sub" id="button-copy-attachments-md">Copy Attachments MD</a>
     </div>
     <div id="list-container-images" class="list-container">
       <div class="not-found-container hidden" id="not-found-container-images">
         <img src="../icons/bufo-sad-but-ok.png" width="50px" height="50px">
         <div>There doesn't seem to be any comments with image attachments!</div>
       </div>
-      <a href="#" class="button button-sub" id="button-copy-images-md">Copy Images MD</a>
     </div>
     <script type="application/javascript" src="../lib/browser-polyfill.min.js"></script>
     <script type="application/javascript" src="popup.js"></script>

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -43,12 +43,14 @@
         <img src="../icons/bufo-sad-but-ok.png" width="50px" height="50px">
         <div>There doesn't seem to be any comments with attachments!</div>
       </div>
+      <a href="#" class="button button-sub" id="button-copy-attachments-md">Copy Attachments MD</a>
     </div>
     <div id="list-container-images" class="list-container">
       <div class="not-found-container hidden" id="not-found-container-images">
         <img src="../icons/bufo-sad-but-ok.png" width="50px" height="50px">
         <div>There doesn't seem to be any comments with image attachments!</div>
       </div>
+      <a href="#" class="button button-sub" id="button-copy-images-md">Copy Images MD</a>
     </div>
     <script type="application/javascript" src="../lib/browser-polyfill.min.js"></script>
     <script type="application/javascript" src="popup.js"></script>

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -447,6 +447,18 @@ function copyAttachmentsMarkdown() {
         )
         .join("\n\n");
       navigator.clipboard.writeText(markdownLinks).then(() => {
+        document.getElementById("attachments-copy").classList.add("hidden");
+        document.getElementById("attachments-check").classList.remove("hidden");
+        document.getElementById("attachments-text").textContent = "Copied!";
+        // Hide the checkmark after 2 seconds.
+        setTimeout(() => {
+          document.getElementById("attachments-check").classList.add("hidden");
+          document
+            .getElementById("attachments-copy")
+            .classList.remove("hidden");
+          document.getElementById("attachments-text").textContent =
+            "Attachments";
+        }, 2000);
         console.log("Attachments copied to clipboard in markdown format.");
       });
     }
@@ -459,11 +471,19 @@ function copyImagesMarkdown() {
     if (data.ticketStorage && data.ticketStorage.images.length > 0) {
       const markdownImages = data.ticketStorage.images
         .map(
-          (image) =>
-            `![${image.fileName}](${image.url}) - Comment on: ${image.createdAt}`
+          (image) => `_${image.fileName}_\n![${image.fileName}](${image.url})`
         )
         .join("\n\n");
       navigator.clipboard.writeText(markdownImages).then(() => {
+        document.getElementById("images-copy").classList.add("hidden");
+        document.getElementById("images-check").classList.remove("hidden");
+        document.getElementById("images-text").textContent = "Copied!";
+        // Hide the checkmark after 2 seconds.
+        setTimeout(() => {
+          document.getElementById("images-check").classList.add("hidden");
+          document.getElementById("images-copy").classList.remove("hidden");
+          document.getElementById("images-text").textContent = "Images";
+        }, 2000);
         console.log("Images copied to clipboard in markdown format.");
       });
     }
@@ -636,6 +656,12 @@ document.addEventListener("DOMContentLoaded", () => {
     document.querySelectorAll(".row-links").forEach((row) => {
       row.classList.add("selected");
     });
+    document.querySelectorAll(".row-attachments").forEach((row) => {
+      row.classList.remove("selected");
+    });
+    document.querySelectorAll(".row-images").forEach((row) => {
+      row.classList.remove("selected");
+    });
 
     document.getElementById("button-attachments").classList.remove("checked");
     document.getElementById("button-images").classList.remove("checked");
@@ -659,7 +685,14 @@ document.addEventListener("DOMContentLoaded", () => {
       document
         .getElementById("list-container-images")
         .classList.remove("selected");
+
       document.querySelectorAll(".row-links").forEach((row) => {
+        row.classList.remove("selected");
+      });
+      document.querySelectorAll(".row-attachments").forEach((row) => {
+        row.classList.add("selected");
+      });
+      document.querySelectorAll(".row-images").forEach((row) => {
         row.classList.remove("selected");
       });
 
@@ -687,6 +720,12 @@ document.addEventListener("DOMContentLoaded", () => {
     // Hide summary and background processing options for images tab
     document.querySelectorAll(".row-links").forEach((row) => {
       row.classList.remove("selected");
+    });
+    document.querySelectorAll(".row-attachments").forEach((row) => {
+      row.classList.remove("selected");
+    });
+    document.querySelectorAll(".row-images").forEach((row) => {
+      row.classList.add("selected");
     });
   });
 

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -432,6 +432,44 @@ async function displayImages(imagesArr) {
     });
 }
 
+// Function to copy all attachments in markdown format to clipboard
+function copyAttachmentsMarkdown() {
+  browser.storage.local.get("ticketStorage").then((data) => {
+    if (data.ticketStorage && data.ticketStorage.attachments.length > 0) {
+      const markdownLinks = data.ticketStorage.attachments
+        .map((attachment) =>
+          attachment.attachments
+            .map(
+              (file) =>
+                `[${file.file_name}](${file.content_url}) - Comment on: ${attachment.created_at}`
+            )
+            .join("\n")
+        )
+        .join("\n\n");
+      navigator.clipboard.writeText(markdownLinks).then(() => {
+        console.log("Attachments copied to clipboard in markdown format.");
+      });
+    }
+  });
+}
+
+// Function to copy all images in markdown format to clipboard
+function copyImagesMarkdown() {
+  browser.storage.local.get("ticketStorage").then((data) => {
+    if (data.ticketStorage && data.ticketStorage.images.length > 0) {
+      const markdownImages = data.ticketStorage.images
+        .map(
+          (image) =>
+            `![${image.fileName}](${image.url}) - Comment on: ${image.createdAt}`
+        )
+        .join("\n\n");
+      navigator.clipboard.writeText(markdownImages).then(() => {
+        console.log("Images copied to clipboard in markdown format.");
+      });
+    }
+  });
+}
+
 // Global options.
 const optionsGlobal = {};
 browser.storage.sync.get("optionsGlobal").then((data) => {
@@ -661,4 +699,12 @@ document.addEventListener("DOMContentLoaded", () => {
     "href",
     `https://github.com/bagtoad/zendesk-link-collector/releases/tag/v${version}`
   );
+
+  // Add event listeners for the new buttons to copy attachments and images in markdown format
+  document
+    .getElementById("button-copy-attachments-md")
+    .addEventListener("click", copyAttachmentsMarkdown);
+  document
+    .getElementById("button-copy-images-md")
+    .addEventListener("click", copyImagesMarkdown);
 });


### PR DESCRIPTION
This PR adds two new buttons to copy attachments and images to clipboard in markdown format. 

Closes #66 

![image](https://github.com/BagToad/Zendesk-Link-Collector/assets/47394200/42cb43d5-1ddd-4531-8c18-f6941449f274)

![image](https://github.com/BagToad/Zendesk-Link-Collector/assets/47394200/e754e4f5-0071-4d58-a678-ff1a31fbe573)
