### PR TITLE
Feature: new options to include attachments and/or images in markdown summary

### DIFF
--- a/src/background/background.js
+++ b/src/background/background.js
@@ -349,6 +349,8 @@ browser.runtime.onInstalled.addListener((data) => {
       optionsGlobal: {
         wrapLists: false,
         backgroundProcessing: false,
+        includeAttachments: true,
+        includeImages: true,
       },
     });
   } else if (reason === "update") {
@@ -371,6 +373,14 @@ browser.runtime.onInstalled.addListener((data) => {
             data.optionsGlobal.backgroundProcessing === undefined
               ? false
               : data.optionsGlobal.backgroundProcessing,
+          includeAttachments:
+            data.optionsGlobal.includeAttachments === undefined
+              ? true
+              : data.optionsGlobal.includeAttachments,
+          includeImages:
+            data.optionsGlobal.includeImages === undefined
+              ? true
+              : data.optionsGlobal.includeImages,
         },
       });
     });

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -6,7 +6,12 @@
 </head>
 <body>
 	<h1>Options Page</h1>
-    <div id="input-container-attachments" class="input-container-row"></div>
+    <div id="input-container-attachments" class="input-container-row">
+        <label class="input-label" title="Include attachments in the markdown summary." for="include-attachments">Include Attachments:</label>
+        <input type="checkbox" id="include-attachments">
+        <label class="input-label" title="Include images in the markdown summary." for="include-images">Include Images:</label>
+        <input type="checkbox" id="include-images">
+    </div>
     <div class="input-container-column">
         <div class="input-container-row">
             <label class="input-label" title="How to handle links that are too long to be displayed in the extension.&#13&#13Enabled = wrap long links.&#13Disabled = scroll long links." for="wrap-lists">Wrap long links?</label>

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -6,16 +6,16 @@
 </head>
 <body>
 	<h1>Options Page</h1>
-    <div id="input-container-attachments" class="input-container-row">
-        <label class="input-label" title="Include attachments in the markdown summary." for="include-attachments">Include Attachments:</label>
-        <input type="checkbox" id="include-attachments">
-        <label class="input-label" title="Include images in the markdown summary." for="include-images">Include Images:</label>
-        <input type="checkbox" id="include-images">
-    </div>
     <div class="input-container-column">
         <div class="input-container-row">
             <label class="input-label" title="How to handle links that are too long to be displayed in the extension.&#13&#13Enabled = wrap long links.&#13Disabled = scroll long links." for="wrap-lists">Wrap long links?</label>
             <input type="checkbox" id="wrap-lists">
+        </div>
+        <div id="input-container-attachments" class="input-container-row">
+            <label class="input-label" title="Include attachments in the markdown summary." for="include-attachments">Include Attachments:</label>
+            <input type="checkbox" id="include-attachments">
+            <label class="input-label" title="Include images in the markdown summary." for="include-images">Include Images:</label>
+            <input type="checkbox" id="include-images">
         </div>
     </div>
     <div id="input-container-save-options" class="input-container-row">

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -428,15 +428,16 @@ function saveGlobalOptions() {
     if (data.optionsGlobal == undefined) {
       data.optionsGlobal = {
         wrapLists: false,
-        includeAttachments: false, // New option for including attachments in markdown summary
-        includeImages: false // New option for including images in markdown summary
+        includeAttachments: false,
+        includeImages: false,
       };
     }
 
     data.optionsGlobal.wrapLists =
       document.getElementById("wrap-lists").checked;
-    data.optionsGlobal.includeAttachments =
-      document.getElementById("include-attachments").checked;
+    data.optionsGlobal.includeAttachments = document.getElementById(
+      "include-attachments"
+    ).checked;
     data.optionsGlobal.includeImages =
       document.getElementById("include-images").checked;
 
@@ -453,7 +454,7 @@ function loadGlobalOptions() {
       data.optionsGlobal = {
         wrapLists: false,
         includeAttachments: false,
-        includeImages: false
+        includeImages: false,
       };
     }
     document.getElementById("wrap-lists").checked =

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -428,14 +428,20 @@ function saveGlobalOptions() {
     if (data.optionsGlobal == undefined) {
       data.optionsGlobal = {
         wrapLists: false,
+        includeAttachments: false, // New option for including attachments in markdown summary
+        includeImages: false // New option for including images in markdown summary
       };
     }
 
     data.optionsGlobal.wrapLists =
       document.getElementById("wrap-lists").checked;
+    data.optionsGlobal.includeAttachments =
+      document.getElementById("include-attachments").checked;
+    data.optionsGlobal.includeImages =
+      document.getElementById("include-images").checked;
 
     browser.storage.sync.set({
-      optionsGlobal: optionsGlobal,
+      optionsGlobal: data.optionsGlobal,
     });
   });
 }
@@ -446,10 +452,16 @@ function loadGlobalOptions() {
     if (data.optionsGlobal == undefined) {
       data.optionsGlobal = {
         wrapLists: false,
+        includeAttachments: false,
+        includeImages: false
       };
     }
     document.getElementById("wrap-lists").checked =
       data.optionsGlobal.wrapLists;
+    document.getElementById("include-attachments").checked =
+      data.optionsGlobal.includeAttachments;
+    document.getElementById("include-images").checked =
+      data.optionsGlobal.includeImages;
   });
 }
 

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -33,6 +33,30 @@ function writeSummaryClipboard() {
       summary += "\n";
     }
   });
+
+  // Include attachments and images in the markdown summary if the respective global options are enabled.
+  // Fallback to enabled if the options are not set or null.
+  browser.storage.sync.get("optionsGlobal").then((data) => {
+    const includeAttachments = data.optionsGlobal?.includeAttachments ?? true;
+    const includeImages = data.optionsGlobal?.includeImages ?? true;
+
+    if (includeAttachments) {
+      summary += "### Attachments\n\n";
+      document.querySelectorAll(".list-item-attachments a").forEach((a) => {
+        summary += `- [${a.textContent}](${a.href})\n`;
+      });
+      summary += "\n";
+    }
+
+    if (includeImages) {
+      summary += "### Images\n\n";
+      document.querySelectorAll(".list-item-images img").forEach((img) => {
+        summary += `![${img.alt}](${img.src})\n`;
+      });
+      summary += "\n";
+    }
+  });
+
   if (summary != "") {
     navigator.clipboard.writeText(summary);
     document.getElementById("summary-copy").classList.add("hidden");

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -11,7 +11,7 @@ function scrollToComment(data) {
 }
 
 // Write the configurable summary to the clipboard.
-function writeSummaryClipboard() {
+async function writeSummaryClipboard() {
   let summary = "";
   document.querySelectorAll(".list-links").forEach((list) => {
     // If "all" summary type, add all to summary.
@@ -36,9 +36,11 @@ function writeSummaryClipboard() {
 
   // Include attachments and images in the markdown summary if the respective global options are enabled.
   // Fallback to enabled if the options are not set or null.
-  browser.storage.sync.get("optionsGlobal").then((data) => {
+  await browser.storage.sync.get("optionsGlobal").then((data) => {
     const includeAttachments = data.optionsGlobal?.includeAttachments ?? true;
     const includeImages = data.optionsGlobal?.includeImages ?? true;
+
+    console.log(includeAttachments, includeImages);
 
     if (includeAttachments) {
       summary += "### Attachments\n\n";


### PR DESCRIPTION
This PR adds new options to include attachments and/or images in markdown summary to the options page. 

These options will be on by default. 

![image](https://github.com/BagToad/Zendesk-Link-Collector/assets/47394200/d4e47dd1-60cf-458e-bca6-38f716ace39b)
