### PR TITLE
Add visual scroll-to comment indicator

### DIFF
--- a/src/content-scripts/contentscript.js
+++ b/src/content-scripts/contentscript.js
@@ -13,6 +13,7 @@ browser.runtime.onMessage.addListener(function (request, sender, sendResponse) {
         document.querySelector(`[id="comment-${request.auditID}"]`);
     if (element) {
       element.scrollIntoView({ behavior: "smooth", block: "center" });
+      highlightComment(element); // Call the new highlight function after scrolling
       return;
     }
 
@@ -31,6 +32,7 @@ browser.runtime.onMessage.addListener(function (request, sender, sendResponse) {
           if (event.type == "Comment") {
             if (comment.outerHTML == event.html_body) {
               comment.scrollIntoView({ behavior: "smooth", block: "center" });
+              highlightComment(comment); // Call the new highlight function after scrolling
               return;
             }
           }
@@ -130,3 +132,12 @@ browser.runtime.onMessage.addListener(function (request, sender, sendResponse) {
 
   return true;
 });
+
+// Function to visually highlight the scrolled-to comment
+function highlightComment(element) {
+  element.style.transition = "background-color 0.5s ease";
+  element.style.backgroundColor = "#ffff99"; // Temporary highlight color
+  setTimeout(() => {
+    element.style.backgroundColor = ""; // Remove highlight after a few seconds
+  }, 2000); // Ensure the highlight fades away after a few seconds
+}

--- a/src/content-scripts/contentscript.js
+++ b/src/content-scripts/contentscript.js
@@ -135,18 +135,21 @@ browser.runtime.onMessage.addListener(function (request, sender, sendResponse) {
 });
 
 function highlightComment(element) {
-  let highlightElement = element.parentElement;
-  // Traverse up the DOM tree until an 'article' element is found
+  let highlightElement = element;
+  let counter = 0;
+  const maxCounter = 20;
+  // Traverse up the DOM tree until an 'article' element is found or counter reaches 10
   while (
     highlightElement &&
-    highlightElement.nodeName.toLowerCase() !== "article"
+    highlightElement.nodeName.toLowerCase() !== "article" &&
+    counter < maxCounter
   ) {
     highlightElement = highlightElement.parentElement;
+    counter++;
   }
 
-  // If an 'article' element is found
+  // If an 'article' element is found or the nth parent is reached, highlight whatever the element is.
   if (highlightElement) {
-    // Save the original background color
     const originalColor = highlightElement.style.backgroundColor;
 
     highlightElement.style.transition = "background-color 0.5s ease";
@@ -159,6 +162,7 @@ function highlightComment(element) {
     // After the transition is complete, remove the style attribute
     setTimeout(() => {
       highlightElement.removeAttribute("style");
-    }, 2500); // Ensure the style attribute is removed after the transition is complete
+    }, 2500); // Ensure the style attribute is removed after the transition is complete.
+    // This is very important to ensure the HTML of this element stays the same as what is returned by the audits endpoint.
   }
 }


### PR DESCRIPTION
Highlight the comment being scrolled to make it easier to see what comment you are scrolling to.

This PR also addresses an issue where the scroll-to comment could have sent multiple responses to the background script/popup script, making one of the messages return an exception.

Closes #63 