### PR TITLE
Add example and default link patterns to extension UI and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You can also manually [install it from the source code](#chrome-manual-installat
 ## Configuration
 Access the configuration page to set link regex patterns you would like to aggregate from tickets.
 
-You can download [a sample JSON file](./samples/link-patterns.json) as a starter. You can import it from the configuration page.
+Some default link patterns will be available when you install the extension. You can also download [a sample JSON file containing the default patterns](./samples/link-patterns.json) to import from the configuration page.
 
 ### Google Chrome and Firefox
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ You can also manually [install it from the source code](#chrome-manual-installat
 ## Configuration
 Access the configuration page to set link regex patterns you would like to aggregate from tickets.
 
+You can download [a sample JSON file](./samples/link-patterns.json) as a starter. You can import it from the configuration page.
+
 ### Google Chrome and Firefox
 
 Click the ⚙️ icon in the top-right corner of the extension popup to open the configuration page.

--- a/samples/link-patterns.json
+++ b/samples/link-patterns.json
@@ -17,7 +17,7 @@
   },
   {
     "id": "9f6bc302-e46a-4621-a55d-fc4af232984d",
-    "pattern": "https:\\/\\/.*\\.zendesk\\.com\\/agent\\/tickets\\/[0-9]+",
+    "pattern": "https://[A-Za-z0-9]+\\.zendesk\\.com/agent/tickets/[0-9]+",
     "showDate": false,
     "showParent": false,
     "summaryType": "all",

--- a/samples/link-patterns.json
+++ b/samples/link-patterns.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "b19a712c-dd34-491f-a43a-c0483f44f045",
+    "pattern": "https:\\/\\/docs\\.github\\.com\\/",
+    "showDate": false,
+    "showParent": false,
+    "summaryType": "none",
+    "title": "GitHub Docs"
+  },
+  {
+    "id": "4adcb721-769c-48cd-b1b4-21bc76addad4",
+    "pattern": "https:\\/\\/github\\.com\\/orgs\\/community\\/discussions",
+    "showDate": true,
+    "showParent": false,
+    "summaryType": "all",
+    "title": "GitHub Discussions"
+  },
+  {
+    "id": "9f6bc302-e46a-4621-a55d-fc4af232984d",
+    "pattern": "https:\\/\\/.*\\.zendesk\\.com\\/agent\\/tickets\\/[0-9]+",
+    "showDate": false,
+    "showParent": false,
+    "summaryType": "all",
+    "title": "Zendesk Tickets"
+  }
+]

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -344,7 +344,7 @@ browser.runtime.onInstalled.addListener((data) => {
   const previousVersion = data.previousVersion;
   if (reason === "install") {
     console.log("Zendesk Link Collector - installed");
-    // Set the default options.
+    // Set the default options on install.
     browser.storage.sync.set({
       optionsGlobal: {
         wrapLists: false,
@@ -352,6 +352,42 @@ browser.runtime.onInstalled.addListener((data) => {
         includeAttachments: true,
         includeImages: true,
       },
+    });
+
+    // Set the default patterns on install.
+    // Check if patterns from a previous installation exist before overwriting them.
+    browser.storage.sync.get("options").then((data) => {
+      if (data.options == undefined || data.options.length <= 0) {
+        browser.storage.sync.set({
+          options: [
+            {
+              id: "b19a712c-dd34-491f-a43a-c0483f44f045",
+              title: "GitHub Docs",
+              pattern: "https:\\/\\/docs\\.github\\.com\\/",
+              showParent: false,
+              summaryType: "none",
+              showDate: false,
+            },
+            {
+              id: "4adcb721-769c-48cd-b1b4-21bc76addad4",
+              title: "GitHub Discussions",
+              pattern:
+                "https:\\/\\/github\\.com\\/orgs\\/community\\/discussions",
+              showParent: false,
+              summaryType: "all",
+              showDate: true,
+            },
+            {
+              id: "9f6bc302-e46a-4621-a55d-fc4af232984d",
+              title: "Zendesk Tickets",
+              pattern: "https://[A-Za-z0-9]+.zendesk.com/agent/tickets/[0-9]+",
+              showParent: false,
+              summaryType: "all",
+              showDate: false,
+            },
+          ],
+        });
+      }
     });
   } else if (reason === "update") {
     console.log(

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -40,6 +40,12 @@
             <input type="checkbox" id="show-date">
             <button id="button-save-link-patterns">Save Link Pattern</button>
         </div>
+        <h2>Example Patterns</h2>
+        <div>
+            <pre>https://docs.github.com</pre>
+            <pre>https://github.com/orgs/community/discussions</pre>
+            <pre>https://*.zendesk.com/agent/tickets/[0-9]+</pre>
+        </div>
         <div id="container-link-patterns-error" class="input-container-row">
             <div class="hidden" id="link-patterns-error">Error: this is an error</div>
         </div>

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -42,9 +42,9 @@
         </div>
         <h2>Example Patterns</h2>
         <div>
-            <pre>https://docs.github.com</pre>
-            <pre>https://github.com/orgs/community/discussions</pre>
-            <pre>https://*.zendesk.com/agent/tickets/[0-9]+</pre>
+            <pre>https:\/\/docs\.github\.com</pre>
+            <pre>https:\/\/github\.com\/orgs\/community\/discussions</pre>
+            <pre>https:\/\/[A-Za-z0-9]+\.zendesk\.com\/agent\/tickets\/[0-9]+</pre>
         </div>
         <div id="container-link-patterns-error" class="input-container-row">
             <div class="hidden" id="link-patterns-error">Error: this is an error</div>


### PR DESCRIPTION
## Copilot generated summary

Enhancements to user experience:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R17-R18): Added a section about downloading a sample JSON file for link patterns to help users understand the format.

* [`src/options/options.html`](diffhunk://#diff-594c44a28df5453d166af1cfc08191e04d1a2576a04161c773b2ea80e2dac86cR43-R48): Added a section to display example patterns for users to understand how they can be written.

Functionality improvements:

* [`src/background/background.js`](diffhunk://#diff-d7072b9c615837a7b1318ff38a6dda1ea436aeb0b8fc073d1b32e52b73378937L347-R347): Updated the extension installation process to set default link patterns. It also checks if patterns from a previous installation exist before overwriting them. [[1]](diffhunk://#diff-d7072b9c615837a7b1318ff38a6dda1ea436aeb0b8fc073d1b32e52b73378937L347-R347) [[2]](diffhunk://#diff-d7072b9c615837a7b1318ff38a6dda1ea436aeb0b8fc073d1b32e52b73378937R356-R391)

Addition of new resources:

* [`samples/link-patterns.json`](diffhunk://#diff-508731a565ace778ca4d84ba7981fb6bbce7c151faa93031b2b7855adcd7ab3dR1-R26): Added a new sample JSON file with link patterns. This serves as a starter for users to understand the format of link patterns.


Closes https://github.com/BagToad/Zendesk-Link-Collector/issues/49.