### PR TITLE
fix: re-inject content scripts so already-open Zendesk tabs keep working after SW activation

### DIFF
--- a/src/background/background.js
+++ b/src/background/background.js
@@ -3,6 +3,67 @@ if (typeof importScripts === "function") {
   importScripts("../lib/browser-polyfill.min.js");
 }
 
+// Inject our content script into already-open Zendesk tabs.
+//
+// MV3 only auto-injects manifest content_scripts into tabs LOADED after
+// the extension is installed/updated/enabled. Tabs that were open before
+// run without our content script — the popup's tabs.sendMessage then
+// fails with "Could not establish connection. Receiving end does not
+// exist."
+//
+// runtime.onInstalled covers fresh install + extension update, but does
+// NOT fire when the user disables and re-enables the extension at
+// chrome://extensions, nor on browser startup with an already-open tab.
+// Calling this from top-level service-worker code below covers all of
+// those cases on every SW activation. The content script's globalThis
+// idempotency guard makes a redundant re-injection a no-op.
+function injectIntoExistingZendeskTabs() {
+  browser.tabs
+    .query({ url: "https://*.zendesk.com/*" })
+    .then((tabs) => {
+      for (const tab of tabs) {
+        browser.scripting
+          .executeScript({
+            target: { tabId: tab.id },
+            // Use the polyfill here (not the lighter shim added in #94) so
+            // this PR stays focused on the injection fix; the polyfill→shim
+            // swap — including this call site — is #94's job. Both paths must
+            // load the same library, otherwise an already-open tab would have
+            // different `browser.*` semantics than a freshly-loaded one.
+            // `runAt: document_start` is matched via `injectImmediately` below.
+            files: [
+              "lib/browser-polyfill.min.js",
+              "content-scripts/contentscript.js",
+            ],
+            injectImmediately: true,
+          })
+          .catch((err) => {
+            // Tab may have navigated away or been closed during injection.
+            console.warn(
+              `Zendesk Link Collector - failed to inject into tab ${tab.id}:`,
+              err.message
+            );
+          });
+      }
+    })
+    .catch((err) => {
+      // Service-worker-level failure (permissions revoked, browser shutdown
+      // mid-callback, etc.). Logged so it doesn't surface as an unhandled
+      // promise rejection on the SW.
+      console.warn(
+        "Zendesk Link Collector - tabs.query failed during injection:",
+        err.message
+      );
+    });
+}
+
+// Run on every SW activation. This catches: extension enable/disable
+// toggle, browser startup with already-open Zendesk tabs, and any other
+// SW restart that doesn't fire onInstalled. Install and update are also
+// covered (onInstalled below calls this too — redundant injection is a
+// no-op thanks to the content script's idempotency guard).
+injectIntoExistingZendeskTabs();
+
 // Sends a message to the content script to execute a fetch.
 // Code from https://stackoverflow.com/questions/55214828/how-to-make-a-cross-origin-request-in-a-content-script-currently-blocked-by-cor/55215898#55215898
 async function fetchResource(input, init) {
@@ -433,6 +494,14 @@ browser.runtime.onInstalled.addListener((data) => {
     //     });
     //   });
     // }
+  }
+
+  // Inject content scripts into already-open Zendesk tabs.
+  // MV3 doesn't auto-inject manifest content_scripts into tabs that were
+  // open before the extension was installed or updated, so the popup can't
+  // communicate with them until the user refreshes the page. This fixes that.
+  if (reason === "install" || reason === "update") {
+    injectIntoExistingZendeskTabs();
   }
 });
 

--- a/src/content-scripts/contentscript.js
+++ b/src/content-scripts/contentscript.js
@@ -1,7 +1,18 @@
+// Idempotent listener registration: stash the named listener function on
+// globalThis. If the script runs twice in the same isolated world (e.g.
+// the manifest content_script auto-injection plus a programmatic
+// re-injection on extension install/update), the previous listener is
+// removed before the new one is added. Works whether the isolated world
+// persists across updates or not, and whether manifest or programmatic
+// injection runs first.
+if (globalThis.__zlcOnMessage) {
+  browser.runtime.onMessage.removeListener(globalThis.__zlcOnMessage);
+}
+
 console.log("Zendesk Link Collector - loaded content script");
 
 // Message handler for messages from the background script.
-browser.runtime.onMessage.addListener(function (request, sender, sendResponse) {
+function zlcOnMessage(request, sender, sendResponse) {
   // Scroll to the comment.
   if (request.type == "scroll") {
     // This is async because it contains a fetch which we must wait for before sending a response.
@@ -132,7 +143,10 @@ browser.runtime.onMessage.addListener(function (request, sender, sendResponse) {
   }
 
   return true;
-});
+}
+
+globalThis.__zlcOnMessage = zlcOnMessage;
+browser.runtime.onMessage.addListener(zlcOnMessage);
 
 function highlightComment(element) {
   let highlightElement = element;

--- a/src/manifest-chrome.json
+++ b/src/manifest-chrome.json
@@ -38,6 +38,6 @@
       "description": "Copy ticket ID to clipboard in markdown"
     }
   },
-  "permissions": ["activeTab", "storage", "clipboardWrite"],
+  "permissions": ["activeTab", "storage", "clipboardWrite", "scripting"],
   "host_permissions": ["https://*.zendesk.com/*"]
 }

--- a/src/manifest-firefox.json
+++ b/src/manifest-firefox.json
@@ -38,7 +38,7 @@
       "description": "Copy ticket ID to clipboard in markdown"
     }
   },
-  "permissions": ["activeTab", "storage", "clipboardWrite"],
+  "permissions": ["activeTab", "storage", "clipboardWrite", "scripting"],
   "host_permissions": ["https://*.zendesk.com/*"],
   "browser_specific_settings": {
     "gecko": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -38,6 +38,6 @@
       "description": "Copy ticket ID to clipboard in markdown"
     }
   },
-  "permissions": ["activeTab", "storage", "clipboardWrite"],
+  "permissions": ["activeTab", "storage", "clipboardWrite", "scripting"],
   "host_permissions": ["https://*.zendesk.com/*"]
 }


### PR DESCRIPTION
## Why

MV3 doesn't auto-inject manifest `content_scripts` into tabs that were already open when the extension's service worker activates. `runtime.onInstalled` only fires on install/update — not on toggle-off/on, browser startup, or SW wake. As a result, every time the SW activates, already-open Zendesk tabs lose their content script and the popup goes silent until the user refreshes the page. This PR re-injects on every SW activation and hardens the content script's listener registration so re-injection is safe.

## Notes for reviewers

Two commits, ordered scaffolding → headline. Each leaves the tree in a working state. The original branch went through several iterations (boolean guard → named-function guard, polyfill vs shim path); those intermediates aren't useful for review and have been squashed into the two commits below.

**`c3c89e9` chore: add 'scripting' permission and idempotent content-script listener**

Pure scaffolding. No user-visible behavior change on its own — these changes are no-ops until the next commit's helper starts using them.

- Adds the `scripting` permission to all three manifests. Required by `browser.scripting.executeScript`, which the next commit will use.
- Switches the content script's `runtime.onMessage` listener registration from an anonymous function to a named function stashed on `globalThis`, with a `removeListener`-then-`addListener` guard. This is what makes re-injection safe: when the content script gets re-injected into a tab where it previously ran, the previous listener is removed before the new one is registered, so messages don't multi-fire. Works regardless of whether the isolated world persists across re-injection (Chrome's behavior here is platform-version-specific and not something we want to depend on).

**`26b5a1d` fix: re-inject content scripts so already-open Zendesk tabs keep working after SW activation**

The headline change.

- Lifts the existing-tab injection into a top-level helper (`injectIntoExistingZendeskTabs`) and calls it so every code path that wakes the SW reattaches the content script: top-level (every SW wake — install, update, toggle-off/on, browser startup, idle-timeout restart) and `runtime.onInstalled` (install / update; calls the helper too, but the content-script's idempotency guard makes a duplicate run a no-op).
- `executeScript` is wired up with `injectImmediately: true` so it matches the manifest's `document_start` timing, and the outer `tabs.query` is wrapped in a `.catch` so SW-level failures don't surface as unhandled rejections.

The Chrome `executeScript` path injects `lib/browser-polyfill.min.js`; PR #94 retires the polyfill in favor of the shim and updates the `executeScript` path to match.

## Test steps

1. `make dev`, load `build/firefox/manifest.json` as a Firefox temporary add-on and `build/chrome` as a Chrome unpacked extension. (Don't use `make build` for local testing — its artifacts use the release `gecko.id` and loading them can clobber your real `browser.storage` data.)
2. Open a Zendesk ticket. Confirm the popup populates with links.
3. Trigger an extension update: edit the version in `src/manifest.json` (or check out a different commit), re-run `make dev`, then reload the extension. The previously-open Zendesk tab — without manual refresh — should still respond to the popup. Before this PR it would not. (This step exercises `runtime.onInstalled` with reason='update'; step 5 below covers the toggle-off/on path.)
4. Reload the same tab manually; popup should continue to work (no duplicate listeners, no double-fire).
5. Open chrome://extensions and toggle the extension off/on; same tab should keep working.
