### PR TITLE
feat: gear dropdown menu with Options and version links

### DIFF
--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -10,6 +10,9 @@
     --primary-bg-light: rgb(33, 38, 45);
     --primary-bg-light-active: rgb(42, 47, 54);
     --secondary: rgb(73, 78, 85);
+
+    /* Width of the gear column in the top row. */
+    --gear-col-width: 39px;
 }
 
 * {
@@ -154,10 +157,6 @@ a:hover {
     cursor: pointer;
 }
 
-#button-whats-new {
-    margin-left: auto;
-}
-
 .row {
     display: flex;
     flex-direction: row;
@@ -178,10 +177,53 @@ a:hover {
 
 #button-options {
     flex-grow: 0;
+    width: var(--gear-col-width);
+    box-sizing: border-box;
 }
 
 #button-options img {
     vertical-align: middle;
+}
+
+/* Gear dropdown container and menu */
+.gear-container {
+    position: relative;
+    display: flex;
+}
+
+.gear-dropdown {
+    display: none;
+    flex-direction: column;
+    position: absolute;
+    top: 100%;
+    right: 0;
+    z-index: 10;
+    min-width: 120px;
+    background-color: var(--primary-bg-light);
+    border: 2px solid var(--secondary);
+    border-top: none;
+}
+
+.gear-dropdown.open {
+    display: flex;
+}
+
+.gear-dropdown-item {
+    padding: 8px 12px;
+    color: rgb(201, 209, 217);
+    text-decoration: none;
+    font-size: 1em;
+    cursor: pointer;
+}
+
+.gear-dropdown-item:hover {
+    background-color: var(--primary-bg-light-active);
+    text-decoration: none;
+}
+
+.gear-version {
+    font-size: 0.85em;
+    color: rgb(201, 209, 217);
 }
 
 /* Loader Styles */

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -12,7 +12,7 @@
       <a href="#" class="button button-fill" id="button-images">Images</a>
       <div class="gear-container">
         <a href="#" class="button button-fill" id="button-options">
-          <img class="icon icon-invert" src="../icons/gear.svg" width="15px" height="15px">
+          <img class="icon icon-invert" src="../icons/gear.svg" alt="" width="15px" height="15px">
         </a>
         <div id="gear-dropdown" class="gear-dropdown">
           <a href="#" class="gear-dropdown-item" id="gear-options">Options</a>

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -10,9 +10,15 @@
         <img class="icon icon-invert" src="../icons/home.svg" width="15px" height="15px" style="margin-right: 3px"><span>Links</span></a>
       <a href="#" class="button button-fill" id="button-attachments">Attachments</a>
       <a href="#" class="button button-fill" id="button-images">Images</a>
-      <a href="#" class="button button-fill" id="button-options">
-        <img class="icon icon-invert" src="../icons/gear.svg" width="15px" height="15px">
-      </a>
+      <div class="gear-container">
+        <a href="#" class="button button-fill" id="button-options">
+          <img class="icon icon-invert" src="../icons/gear.svg" width="15px" height="15px">
+        </a>
+        <div id="gear-dropdown" class="gear-dropdown">
+          <a href="#" class="gear-dropdown-item" id="gear-options">Options</a>
+          <a href="#" class="gear-dropdown-item gear-version" id="gear-version" target="_blank"></a>
+        </div>
+      </div>
     </div>
     <div class="row row-sub row-links selected">
       <a href="#" title="Copy a configurable summary to clipboard in markdown. See the options page for configuration options." class="button button-sub" id="button-summary">
@@ -28,7 +34,6 @@
         <img class="icon-button" id="refresh" src="../icons/loader.svg" width="15px" height="15px">
         <span for="refresh">Refresh</span>
       </a>
-      <a href="#" class="button button-sub" id="button-whats-new" target="_blank"></a>
     </div>
     <div class="row row-sub row-attachments">
       <a href="#" class="button button-sub" id="button-copy-attachments-md">

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -648,9 +648,33 @@ document.addEventListener("DOMContentLoaded", () => {
       browser.runtime.openOptionsPage();
     });
 
-  // Event listener to open options when options button is clicked.
-  document.getElementById("button-options").addEventListener("click", () => {
+  // Event listener to toggle the gear dropdown when the gear icon is clicked.
+  const gearDropdown = document.getElementById("gear-dropdown");
+  document.getElementById("button-options").addEventListener("click", (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    gearDropdown.classList.toggle("open");
+  });
+
+  // Close the gear dropdown when clicking outside of it.
+  document.addEventListener("click", (e) => {
+    if (!gearDropdown.contains(e.target)) {
+      gearDropdown.classList.remove("open");
+    }
+  });
+
+  // Close the gear dropdown on Escape key.
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape") {
+      gearDropdown.classList.remove("open");
+    }
+  });
+
+  // Open the options page from within the gear dropdown.
+  document.getElementById("gear-options").addEventListener("click", (e) => {
+    e.preventDefault();
     browser.runtime.openOptionsPage();
+    window.close();
   });
 
   // Event listener to copy summary to clipboard when summary button is clicked.
@@ -776,14 +800,15 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   });
 
-  // Dynamically retrieve the version number from manifest.json and insert it into the "What's new?" button text.
+  // Dynamically retrieve the version number from manifest.json and link the
+  // gear-dropdown version item to the latest GitHub release.
   const manifestData = browser.runtime.getManifest();
   const version = manifestData.version;
-  const whatsNewButton = document.getElementById("button-whats-new");
-  whatsNewButton.textContent = `v${version}`;
-  whatsNewButton.setAttribute(
+  const gearVersion = document.getElementById("gear-version");
+  gearVersion.textContent = `v${version}`;
+  gearVersion.setAttribute(
     "href",
-    `https://github.com/bagtoad/zendesk-link-collector/releases/tag/v${version}`
+    `https://github.com/bagtoad/zendesk-link-collector/releases/latest`
   );
 
   // Add event listeners for the new buttons to copy attachments and images in markdown format


### PR DESCRIPTION
## Summary

Replaces the always-visible "What's new?" link in the popup sub-row with a small dropdown attached to the gear icon. The dropdown contains an **Options** entry and a **v\<version\>** link that points to the GitHub releases/latest page.

## Notes for reviewers

- One commit, three files: `popup.html`, `popup.css`, `popup.js`.
- `#button-whats-new` is fully removed (HTML, CSS rule, JS event wiring) — its job moves into the dropdown's version item.
- Dropdown UX: toggles on gear click, closes on outside click / Escape / item activation.
- Version link uses `/releases/latest` instead of a per-version tag URL so it doesn't go stale between version bumps.
- This also frees horizontal space in the top row that a follow-up PR will use to host a search input + clear button on every tab. Search itself is **not** in this PR.

## Test steps

1. `make dev`, load `build/firefox/manifest.json` as a Firefox temporary add-on and `build/chrome` as a Chrome unpacked extension. (Don't use `make build` for local testing — its artifacts use the release `gecko.id` and loading them can clobber your real `browser.storage` data.)
2. Click the gear → dropdown appears with "Options" and "v1.4.0".
3. Click outside or press Escape → dropdown closes.
4. Click "Options" → options page opens, popup closes.
5. Click "v1.4.0" → opens the latest release page in a new tab.
