### PR TITLE
fix: blank link text, self-referencing links, and URL anchor fragments

### DIFF
--- a/src/background/background.js
+++ b/src/background/background.js
@@ -68,9 +68,12 @@ async function filterTicket() {
   // Get make a real URL from the text URL.
   const url = new URL(tab.url);
 
-  // Get the ticket ID from the URL.
-  const stringArr = url.href.split("/");
-  const ticketID = stringArr[stringArr.length - 1];
+  // Get the ticket ID from the URL. Use a regex on pathname so trailing
+  // slashes, query strings, and fragments don't poison the extracted ID
+  // (`split("/").pop()` on `…/tickets/123/` would yield `""`, which then
+  // makes the self-reference filter below match every ticket link).
+  const ticketIDMatch = url.pathname.match(/\/tickets\/(\d+)/);
+  const ticketID = ticketIDMatch ? ticketIDMatch[1] : "";
 
   // Comment collecting loop section
   // *******************************
@@ -218,6 +221,25 @@ async function filterTicket() {
     const filteredLinksArr = [];
     linksArr.forEach((link) => {
       const re = new RegExp(filter.pattern);
+      // Skip links that point back to the currently open ticket — these
+      // self-references add noise without value. Use exact path comparison
+      // (parsed URL) so a substring match on `/tickets/123` doesn't also
+      // hide unrelated tickets like `/tickets/1234`. If we couldn't extract
+      // a ticket ID, skip the filter to avoid masking every ticket link.
+      if (ticketID) {
+        try {
+          const linkUrl = new URL(link.href);
+          if (
+            linkUrl.hostname === url.hostname &&
+            linkUrl.pathname.replace(/\/$/, "") ===
+              `/agent/tickets/${ticketID}`
+          ) {
+            return;
+          }
+        } catch (_e) {
+          // Malformed link.href — fall through and let the regex decide.
+        }
+      }
       if (re.test(link.href)) {
         const link2Push = Object.assign({}, link);
         link2Push.summaryType =

--- a/src/content-scripts/contentscript.js
+++ b/src/content-scripts/contentscript.js
@@ -69,11 +69,33 @@ browser.runtime.onMessage.addListener(function (request, sender, sendResponse) {
     const doc = parser.parseFromString(request.htmlText, "text/html");
     const links = doc.querySelectorAll(`a`);
     const linksArr = [];
+    // Pattern that identifies a Zendesk agent ticket URL. Hash-stripping is
+    // safe for these (the fragment is unreliable across views) but would
+    // collapse meaningful anchors elsewhere (GitHub comments, doc sections,
+    // Jira/Slack permalinks), so we scope it explicitly.
+    const ZENDESK_TICKET_PATH = /^\/agent\/tickets\/\d+\/?$/;
     links.forEach((link) => {
+      // Anchors without href, or with malformed href, throw on `new URL(...)`.
+      // A single bad anchor would propagate out of forEach and abort the
+      // entire response — every subsequent link silently lost. Guard so the
+      // bad anchor is dropped and the rest of the parse continues.
+      let cleanHref;
+      try {
+        const url = new URL(link.href);
+        if (
+          url.hostname === location.hostname &&
+          ZENDESK_TICKET_PATH.test(url.pathname)
+        ) {
+          url.hash = "";
+        }
+        cleanHref = url.toString();
+      } catch (_e) {
+        return;
+      }
       linksArr.push({
         parent_text: link.parentElement.innerHTML,
         text: link.innerText,
-        href: link.href,
+        href: cleanHref,
       });
     });
     sendResponse(linksArr);

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -253,7 +253,10 @@ async function displayLinks(linksBundle) {
             "data-created-at"
           )}\nLink source: ${li.getAttribute("data-source")}`
         );
-        a.textContent = link.text;
+        // Fall back to the URL when anchor text is empty or whitespace-only
+        // so the entry stays visible. Zendesk ticket links commonly have no
+        // inner text; some anchors carry only whitespace from formatting.
+        a.textContent = link.text?.trim() || link.href;
         li.appendChild(a);
       }
 


### PR DESCRIPTION
## Summary

Three small, independent display bugs in the link extraction pipeline. **+52 / −5** across three files.

## Notes for reviewers

Three commits, three files, three independent fixes. Each commit is atomic and reviewable on its own — they share no code paths and can land in any order.

1. **`fc87dcd` fix: fall back to URL when link anchor text is empty** (`src/popup/popup.js`) — Zendesk ticket links often wrap an icon with no inner text; without a fallback the popup row renders blank. Trims before the truthy check so whitespace-only text (`"\n  "`) also falls back.

2. **`2ece25c` fix: skip self-referencing links to the current ticket** (`src/background/background.js`) — Filters out links whose href points back to the open ticket so the popup doesn't list a row that just loops back. Uses a `pathname` regex to extract the ticket ID and a parsed-URL exact-path comparison for the filter (avoids prefix collisions like 123/1234/12345). Skips the filter when the active URL has no ticket ID — better to show a self-reference than to mask every ticket link.

3. **`2d46fbd` fix: strip URL fragments from extracted links** (`src/content-scripts/contentscript.js`) — Anchor fragments (e.g. `#comment-456`) on Zendesk URLs are display noise that fragments otherwise-identical links into separate rows. Scoped to Zendesk hosts, and skips hrefless `<a>` elements (otherwise the empty-href branch threw on `new URL("")`).

## Test steps

1. Open a Zendesk ticket whose body links to: a ticket with empty anchor text, a link back to the same ticket, and a link with `#fragment`.
2. Click the extension icon. Popup should show: a row labeled with the URL (not blank), no row for the self-reference, fragment-stripped versions of any duplicates.
3. Edge: a ticket whose URL has a trailing slash should not blanket-filter all ticket links.
