### PR TITLE
fix(a11y): first accessibility pass — keyboard support, focus styles, ARIA names

### DIFF
--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -372,3 +372,13 @@ li.list-item-attachments ul li {
 #list-container-images.selected {
     display: flex;
 }
+/* Focus-visible outlines for keyboard navigation. The negative
+   outline-offset keeps the outline visible inside overflow:auto
+   containers that would otherwise clip it. */
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+.icon-li:focus-visible {
+    outline: 2px solid var(--accent-light);
+    outline-offset: -2px;
+}

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -44,7 +44,7 @@
         <span id="images-text">All Images</span>
       </a>
     </div>
-    <div id="container" style="display: flex">
+    <div id="container" tabindex="-1" style="display: flex">
     <div id="loader" class="loading"></div>
     <div id="list-container-links" class="list-container selected">
       <div class="not-found-container hidden" id="not-found-container-links">

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="popup.css">
@@ -7,7 +7,7 @@
   <body>
     <div class="row" id="viewOption">
       <a href="#" class="button button-fill checked" id="button-links">
-        <img class="icon icon-invert" src="../icons/home.svg" width="15px" height="15px" style="margin-right: 3px"><span>Links</span></a>
+        <img class="icon icon-invert" src="../icons/home.svg" alt="" width="15px" height="15px" style="margin-right: 3px"><span>Links</span></a>
       <a href="#" class="button button-fill" id="button-attachments">Attachments</a>
       <a href="#" class="button button-fill" id="button-images">Images</a>
       <a href="#" class="button button-fill" id="button-options">
@@ -16,8 +16,8 @@
     </div>
     <div class="row row-sub row-links selected">
       <a href="#" title="Copy a configurable summary to clipboard in markdown. See the options page for configuration options." class="button button-sub" id="button-summary">
-        <img class="icon-button hidden" id="summary-check" src="../icons/check.svg" width="15px" height="15px">
-        <img class="icon-button icon-invert" id="summary-copy" src="../icons/copy.svg" width="15px" height="15px">
+        <img class="icon-button hidden" id="summary-check" src="../icons/check.svg" alt="" width="15px" height="15px">
+        <img class="icon-button icon-invert" id="summary-copy" src="../icons/copy.svg" alt="" width="15px" height="15px">
         <span id="summary-text">Summary</span>
       </a>
       <a href="#" title="Fetch and process ticket data in the background any time a new ticket is viewed, when a zendesk ticket browser tab is opened, and when link patterns change.&#13&#13This can result in better perceived load times, but can also result in more calls to Zendesk depending on your usage patterns." class="button button-sub" id="button-background-processing">
@@ -25,22 +25,22 @@
         <span for="background-processing">Run in Background</span>
       </a>
       <a href="#" title="" class="button button-sub" id="button-refresh">
-        <img class="icon-button" id="refresh" src="../icons/loader.svg" width="15px" height="15px">
-        <span for="refresh">Refresh</span>
+        <img class="icon-button" id="refresh" src="../icons/loader.svg" alt="" width="15px" height="15px">
+        <span>Refresh</span>
       </a>
       <a href="#" class="button button-sub" id="button-whats-new" target="_blank"></a>
     </div>
     <div class="row row-sub row-attachments">
       <a href="#" class="button button-sub" id="button-copy-attachments-md">
-        <img class="icon-button hidden" id="attachments-check" src="../icons/check.svg" width="15px" height="15px">
-        <img class="icon-button icon-invert" id="attachments-copy" src="../icons/copy.svg" width="15px" height="15px">
+        <img class="icon-button hidden" id="attachments-check" src="../icons/check.svg" alt="" width="15px" height="15px">
+        <img class="icon-button icon-invert" id="attachments-copy" src="../icons/copy.svg" alt="" width="15px" height="15px">
         <span id="attachments-text">All Attachments</span>
       </a>
     </div>
     <div class="row row-sub row-images">
       <a href="#" class="button button-sub" id="button-copy-images-md">
-        <img class="icon-button hidden" id="images-check" src="../icons/check.svg" width="15px" height="15px">
-        <img class="icon-button icon-invert" id="images-copy" src="../icons/copy.svg" width="15px" height="15px">
+        <img class="icon-button hidden" id="images-check" src="../icons/check.svg" alt="" width="15px" height="15px">
+        <img class="icon-button icon-invert" id="images-copy" src="../icons/copy.svg" alt="" width="15px" height="15px">
         <span id="images-text">All Images</span>
       </a>
     </div>

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -194,6 +194,9 @@ async function displayLinks(linksBundle) {
         iScroll.setAttribute("commentID", link.commentID);
         iScroll.setAttribute("auditID", link.auditID);
         iScroll.setAttribute("title", "Scroll to link's source comment.");
+        iScroll.setAttribute("role", "button");
+        iScroll.setAttribute("tabindex", "0");
+        iScroll.setAttribute("aria-label", "Scroll to source comment");
         li.appendChild(iScroll);
       }
 
@@ -201,6 +204,9 @@ async function displayLinks(linksBundle) {
       const iCopy = document.createElement("i");
       iCopy.setAttribute("class", "icon-invert icon-li icon-copy");
       iCopy.setAttribute("title", "Copy link to markdown.");
+      iCopy.setAttribute("role", "button");
+      iCopy.setAttribute("tabindex", "0");
+      iCopy.setAttribute("aria-label", "Copy link as markdown");
       li.appendChild(iCopy);
 
       // Add link content or parent context to list item.
@@ -298,11 +304,19 @@ async function displayLinks(linksBundle) {
     .getElementById("list-container-links")
     .querySelectorAll("i.icon-search")
     .forEach((i) => {
-      i.addEventListener("click", () => {
+      const handler = () => {
         scrollToComment({
           commentID: i.getAttribute("commentID"),
           auditID: i.getAttribute("auditID"),
         });
+      };
+      i.addEventListener("click", handler);
+      // Keyboard activation for the focusable icon button.
+      i.addEventListener("keydown", (e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          handler();
+        }
       });
     });
 
@@ -311,10 +325,18 @@ async function displayLinks(linksBundle) {
     .getElementById("list-container-links")
     .querySelectorAll("i.icon-copy")
     .forEach((i) => {
-      i.addEventListener("click", () => {
+      const handler = () => {
         const href = i.parentElement.querySelector("a").href;
         const text = i.parentElement.textContent;
         writeLinkClipboard(text, href);
+      };
+      i.addEventListener("click", handler);
+      // Keyboard activation for the focusable icon button.
+      i.addEventListener("keydown", (e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          handler();
+        }
       });
     });
 

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -283,10 +283,20 @@ async function displayLinks(linksBundle) {
           "title",
           `Click to copy time in UTC\n\n${link.createdAt}`
         );
+        spanDate.setAttribute("role", "button");
+        spanDate.setAttribute("tabindex", "0");
+        spanDate.setAttribute("aria-label", `Copy date ${spanDate.textContent}`);
         li.appendChild(spaceNode);
         li.appendChild(spanDate);
         spanDate.addEventListener("click", () => {
           navigator.clipboard.writeText(link.createdAt);
+        });
+        // Keyboard activation: Enter or Space copies the timestamp.
+        spanDate.addEventListener("keydown", (e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            navigator.clipboard.writeText(link.createdAt);
+          }
         });
       }
 


### PR DESCRIPTION
## Summary

A first accessibility pass on the popup and options pages. Six tightly-scoped atomic commits, each addressing one a11y concern:

1. **Semantic HTML** — `lang="en"`, `alt=""` on decorative icons, fixes invalid `<span for="…">` to plain `<span>`.
2. **Reorder buttons → arrow glyphs + accessible names** — replaces the link-pattern Up/Down buttons with ▲/▼ + `title`/`aria-label`. Closes #16.
3. **Focus-visible outlines** — adds a green outline on links/buttons/inputs in both pages. Popup uses negative `outline-offset` so the outline isn't clipped by overflow:auto containers.
4. **Phantom tab stop fix** — `tabindex="-1"` on `#container` so Firefox doesn't add the scrollable div to the tab order.
5. **Icon button keyboard support (links list)** — `role="button"`, `tabindex="0"`, `aria-label`, plus Enter/Space keydown handlers on the per-link scroll-to-comment and copy-as-markdown icons.
6. **Date span keyboard support** — same treatment for the click-to-copy date span next to each link.

## Notes for reviewers

- 6 commits, 6 files, **+73 / -19**. Each commit is independent and can be reviewed/cherry-picked on its own.
- Scoped to elements that exist on `main` today. The links list got the bulk of the keyboard work because that's where the original a11y commit focused; the equivalent treatment for Attachments/Images icon buttons is intentionally a follow-up to keep this PR atomic.

## Test steps

1. `make dev`, load `build/firefox/manifest.json` as a Firefox temporary add-on and `build/chrome` as a Chrome unpacked extension. (Don't use `make build` for local testing — its artifacts use the release `gecko.id` and loading them can clobber your real `browser.storage` data.)
2. Tab through the popup with the keyboard — every interactive element should show the green focus ring, including the row buttons, sub-row buttons, and the per-link scroll/copy icons.
3. With the date span focused, press Enter — it should copy the UTC timestamp (matches the click handler).
4. With a per-link scroll or copy icon focused, press Space — it should activate the same as a click.
5. Open the options page, focus a link-pattern row — the Up/Down buttons now show as ▲/▼ and announce "Move up"/"Move down" to screen readers.
6. Tab past the end of the row buttons in the popup — focus should jump straight into the list, not pause on the scrollable container.
