### PR TITLE
feat: live search box on every popup tab

### DIFF
--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -11,7 +11,7 @@
     --primary-bg-light-active: rgb(42, 47, 54);
     --secondary: rgb(73, 78, 85);
 
-    /* Width of the gear column in the top row. */
+    /* Shared width for the gear column and the search clear button column */
     --gear-col-width: 39px;
 }
 
@@ -70,11 +70,16 @@
 }
   
 
+html {
+    font-size: 16px;
+}
+
 body {
     width: fit-content;
     height: fit-content;
     border-radius: 0.5em;
     font-family: sans-serif;
+    font-size: 1rem;
     color: rgb(201, 209, 217);
     background-color: var(--primary-bg);
     text-decoration: none;
@@ -141,11 +146,12 @@ a:hover {
 
 .button-sub {
     display: flex;
+    align-items: center;
     justify-content: flex-start;
     column-gap: 10px;
     padding: 0.5em;
     font-size: 1em;
-    border-width: 1px;
+    border-width: 2px;
 }
 
 .button-sub label:hover, .button-sub input:hover {
@@ -173,6 +179,7 @@ a:hover {
 
 .row-sub.selected {
     display: flex;
+    align-items: stretch;
 }
 
 #button-options {
@@ -224,6 +231,69 @@ a:hover {
 .gear-version {
     font-size: 0.85em;
     color: rgb(201, 209, 217);
+}
+
+/* Search group: input + clear button, pinned right in sub-rows */
+.search-group {
+    margin-left: auto;
+    display: flex;
+    align-items: stretch;
+}
+
+.search-input {
+    width: 250px;
+    padding: 0.5em;
+    font-family: inherit;
+    font-size: 1em;
+    line-height: inherit;
+    color: rgb(201, 209, 217);
+    background-color: var(--primary-bg);
+    border: 2px solid var(--secondary);
+    outline: none;
+    appearance: none;
+    -webkit-appearance: none;
+}
+
+.search-input::placeholder {
+    color: var(--secondary);
+}
+
+.search-input:focus {
+    background-color: var(--primary-bg-light-active);
+}
+
+.search-clear-btn {
+    width: var(--gear-col-width);
+    min-width: var(--gear-col-width);
+    padding: 0;
+    font-family: inherit;
+    font-size: 1.2em;
+    font-weight: normal;
+    line-height: 1;
+    text-align: center;
+    color: rgb(201, 209, 217);
+    background-color: var(--primary-bg-light);
+    border: 2px solid var(--secondary);
+    cursor: pointer;
+    box-sizing: border-box;
+    appearance: none;
+    -webkit-appearance: none;
+}
+
+.search-clear-btn:hover {
+    background-color: var(--primary-bg-light-active);
+}
+
+/* "No matches found" message shown when search filters everything */
+.no-search-results {
+    padding: 20px;
+    text-align: center;
+    color: var(--secondary);
+    font-size: 14px;
+}
+
+.no-search-results.hidden {
+    display: none;
 }
 
 /* Loader Styles */

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -10,6 +10,9 @@
     --primary-bg-light: rgb(33, 38, 45);
     --primary-bg-light-active: rgb(42, 47, 54);
     --secondary: rgb(73, 78, 85);
+
+    /* Width of the gear column in the top row. */
+    --gear-col-width: 39px;
 }
 
 * {
@@ -154,10 +157,6 @@ a:hover {
     cursor: pointer;
 }
 
-#button-whats-new {
-    margin-left: auto;
-}
-
 .row {
     display: flex;
     flex-direction: row;
@@ -178,10 +177,53 @@ a:hover {
 
 #button-options {
     flex-grow: 0;
+    width: var(--gear-col-width);
+    box-sizing: border-box;
 }
 
 #button-options img {
     vertical-align: middle;
+}
+
+/* Gear dropdown container and menu */
+.gear-container {
+    position: relative;
+    display: flex;
+}
+
+.gear-dropdown {
+    display: none;
+    flex-direction: column;
+    position: absolute;
+    top: 100%;
+    right: 0;
+    z-index: 10;
+    min-width: 120px;
+    background-color: var(--primary-bg-light);
+    border: 2px solid var(--secondary);
+    border-top: none;
+}
+
+.gear-dropdown.open {
+    display: flex;
+}
+
+.gear-dropdown-item {
+    padding: 8px 12px;
+    color: rgb(201, 209, 217);
+    text-decoration: none;
+    font-size: 1em;
+    cursor: pointer;
+}
+
+.gear-dropdown-item:hover {
+    background-color: var(--primary-bg-light-active);
+    text-decoration: none;
+}
+
+.gear-version {
+    font-size: 0.85em;
+    color: rgb(201, 209, 217);
 }
 
 /* Loader Styles */

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -12,7 +12,7 @@
       <a href="#" class="button button-fill" id="button-images">Images</a>
       <div class="gear-container">
         <a href="#" class="button button-fill" id="button-options">
-          <img class="icon icon-invert" src="../icons/gear.svg" width="15px" height="15px">
+          <img class="icon icon-invert" src="../icons/gear.svg" alt="" width="15px" height="15px">
         </a>
         <div id="gear-dropdown" class="gear-dropdown">
           <a href="#" class="gear-dropdown-item" id="gear-options">Options</a>

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -10,9 +10,15 @@
         <img class="icon icon-invert" src="../icons/home.svg" width="15px" height="15px" style="margin-right: 3px"><span>Links</span></a>
       <a href="#" class="button button-fill" id="button-attachments">Attachments</a>
       <a href="#" class="button button-fill" id="button-images">Images</a>
-      <a href="#" class="button button-fill" id="button-options">
-        <img class="icon icon-invert" src="../icons/gear.svg" width="15px" height="15px">
-      </a>
+      <div class="gear-container">
+        <a href="#" class="button button-fill" id="button-options">
+          <img class="icon icon-invert" src="../icons/gear.svg" width="15px" height="15px">
+        </a>
+        <div id="gear-dropdown" class="gear-dropdown">
+          <a href="#" class="gear-dropdown-item" id="gear-options">Options</a>
+          <a href="#" class="gear-dropdown-item gear-version" id="gear-version" target="_blank"></a>
+        </div>
+      </div>
     </div>
     <div class="row row-sub row-links selected">
       <a href="#" title="Copy a configurable summary to clipboard in markdown. See the options page for configuration options." class="button button-sub" id="button-summary">
@@ -28,7 +34,6 @@
         <img class="icon-button" id="refresh" src="../icons/loader.svg" width="15px" height="15px">
         <span for="refresh">Refresh</span>
       </a>
-      <a href="#" class="button button-sub" id="button-whats-new" target="_blank"></a>
     </div>
     <div class="row row-sub row-attachments">
       <a href="#" class="button button-sub" id="button-copy-attachments-md">

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -34,6 +34,10 @@
         <img class="icon-button" id="refresh" src="../icons/loader.svg" width="15px" height="15px">
         <span for="refresh">Refresh</span>
       </a>
+      <div class="search-group">
+        <input type="text" class="search-input" id="search-links" placeholder="Search by link text...">
+        <button class="search-clear-btn" id="clear-search-links" title="Clear search">⌫</button>
+      </div>
     </div>
     <div class="row row-sub row-attachments">
       <a href="#" class="button button-sub" id="button-copy-attachments-md">
@@ -41,6 +45,10 @@
         <img class="icon-button icon-invert" id="attachments-copy" src="../icons/copy.svg" width="15px" height="15px">
         <span id="attachments-text">All Attachments</span>
       </a>
+      <div class="search-group">
+        <input type="text" class="search-input" id="search-attachments" placeholder="Search by file name...">
+        <button class="search-clear-btn" id="clear-search-attachments" title="Clear search">⌫</button>
+      </div>
     </div>
     <div class="row row-sub row-images">
       <a href="#" class="button button-sub" id="button-copy-images-md">
@@ -48,6 +56,10 @@
         <img class="icon-button icon-invert" id="images-copy" src="../icons/copy.svg" width="15px" height="15px">
         <span id="images-text">All Images</span>
       </a>
+      <div class="search-group">
+        <input type="text" class="search-input" id="search-images" placeholder="Search by file name...">
+        <button class="search-clear-btn" id="clear-search-images" title="Clear search">⌫</button>
+      </div>
     </div>
     <div id="container" style="display: flex">
     <div id="loader" class="loading"></div>
@@ -57,18 +69,21 @@
         <div>There doesn't seem to be any comments matching link patterns!</div>
         <div>Try adding more link patterns in the <a href="#" id="not-found-link-patterns-options">options page.</a></div>
       </div>
+      <div class="no-search-results hidden" id="no-search-results-links">No matches found.</div>
     </div>
     <div id="list-container-attachments" class="list-container">
       <div class="not-found-container hidden" id="not-found-container-attachments">
         <img src="../icons/bufo-sad-but-ok.png" width="50px" height="50px">
         <div>There doesn't seem to be any comments with attachments!</div>
       </div>
+      <div class="no-search-results hidden" id="no-search-results-attachments">No matches found.</div>
     </div>
     <div id="list-container-images" class="list-container">
       <div class="not-found-container hidden" id="not-found-container-images">
         <img src="../icons/bufo-sad-but-ok.png" width="50px" height="50px">
         <div>There doesn't seem to be any comments with image attachments!</div>
       </div>
+      <div class="no-search-results hidden" id="no-search-results-images">No matches found.</div>
     </div>
     <script type="application/javascript" src="../lib/browser-polyfill.min.js"></script>
     <script type="application/javascript" src="popup.js"></script>

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -418,8 +418,8 @@ async function displayImages(imagesArr) {
   // Get images container
   const imagesList = document.getElementById("list-container-images");
 
-  // Clear the images container of previous content
-  imagesList.innerHTML = "";
+  // Clear previous image lists without removing the status message divs.
+  imagesList.querySelectorAll("ul.list-images").forEach((el) => el.remove());
 
   const ul = document.createElement("ul");
   ul.setAttribute("class", "list-images");
@@ -547,6 +547,115 @@ browser.storage.sync.get("optionsGlobal").then((data) => {
   optionsGlobal.backgroundProcessing = data.optionsGlobal.backgroundProcessing;
 });
 
+// Filter list items by a search query using case-insensitive substring matching.
+// Shows/hides items based on whether their searchable text contains the query.
+// For the Links tab, also hides headers (h3) when all items in the following list are hidden.
+function filterLinks(query) {
+  const container = document.getElementById("list-container-links");
+  const lowerQuery = query.toLowerCase();
+  let anyVisible = false;
+
+  // Iterate each header + list pair.
+  container.querySelectorAll("ul.list-links").forEach((ul) => {
+    let groupVisible = false;
+    ul.querySelectorAll("li.list-item-links").forEach((li) => {
+      const matches = lowerQuery === "" || li.textContent.toLowerCase().includes(lowerQuery);
+      li.style.display = matches ? "" : "none";
+      if (matches) groupVisible = true;
+    });
+
+    // Hide the associated header if no items in this group matched.
+    const header = ul.previousElementSibling;
+    if (header && header.tagName === "H3") {
+      header.style.display = groupVisible ? "" : "none";
+    }
+    ul.style.display = groupVisible ? "" : "none";
+    if (groupVisible) anyVisible = true;
+  });
+
+  // Show "no matches" message if query is active but nothing matched.
+  // Don't show it if the dataset itself is empty (not-found-container is visible).
+  const noResults = document.getElementById("no-search-results-links");
+  const dataEmpty = !document.getElementById("not-found-container-links").classList.contains("hidden");
+  noResults.classList.toggle("hidden", dataEmpty || lowerQuery === "" || anyVisible);
+}
+
+function filterAttachments(query) {
+  const container = document.getElementById("list-container-attachments");
+  const lowerQuery = query.toLowerCase();
+  let anyVisible = false;
+
+  // Filter individual attachment items within each comment group.
+  // Hide the parent comment group if none of its child attachments match.
+  // Use `:scope >` to avoid matching nested items at the wrong level,
+  // since both levels share the same ul/li class names.
+  const topUl = container.querySelector(":scope > ul.list-attachments");
+  if (!topUl) return;
+  topUl.querySelectorAll(":scope > li.list-item-attachments").forEach((commentGroup) => {
+    let groupVisible = false;
+    // Check each nested attachment file item within this comment group.
+    const fileItems = commentGroup.querySelectorAll(":scope > ul.list-attachments > li.list-item-attachments");
+    fileItems.forEach((fileLi) => {
+      const matches = lowerQuery === "" || fileLi.textContent.toLowerCase().includes(lowerQuery);
+      fileLi.style.display = matches ? "" : "none";
+      if (matches) groupVisible = true;
+    });
+
+    // Also match on the comment date text in the parent group.
+    if (!groupVisible && lowerQuery !== "") {
+      // Check if the comment group's own direct text (date) matches.
+      const ownText = Array.from(commentGroup.childNodes)
+        .filter((n) => n.nodeType === Node.TEXT_NODE || n.tagName === "I")
+        .map((n) => n.textContent)
+        .join("")
+        .toLowerCase();
+      if (ownText.includes(lowerQuery)) {
+        // Date matched — show all file items in this group.
+        fileItems.forEach((fileLi) => {
+          fileLi.style.display = "";
+        });
+        groupVisible = true;
+      }
+    }
+
+    commentGroup.style.display = groupVisible ? "" : "none";
+    if (groupVisible) anyVisible = true;
+  });
+
+  const noResults = document.getElementById("no-search-results-attachments");
+  const dataEmpty = !document.getElementById("not-found-container-attachments").classList.contains("hidden");
+  noResults.classList.toggle("hidden", dataEmpty || lowerQuery === "" || anyVisible);
+}
+
+function filterImages(query) {
+  const container = document.getElementById("list-container-images");
+  const lowerQuery = query.toLowerCase();
+  let anyVisible = false;
+
+  // Filter images by their file name (stored in the img alt attribute).
+  container.querySelectorAll("li.list-item-images").forEach((li) => {
+    const img = li.querySelector("img");
+    const fileName = img ? img.alt.toLowerCase() : "";
+    const matches = lowerQuery === "" || fileName.includes(lowerQuery);
+    li.style.display = matches ? "" : "none";
+    if (matches) anyVisible = true;
+  });
+
+  const noResults = document.getElementById("no-search-results-images");
+  const dataEmpty = !document.getElementById("not-found-container-images").classList.contains("hidden");
+  noResults.classList.toggle("hidden", dataEmpty || lowerQuery === "" || anyVisible);
+}
+
+// Re-apply all active search filters. Called after content re-renders (e.g., refresh).
+function reapplySearchFilters() {
+  const linksInput = document.getElementById("search-links");
+  const attachmentsInput = document.getElementById("search-attachments");
+  const imagesInput = document.getElementById("search-images");
+  if (linksInput.value) filterLinks(linksInput.value);
+  if (attachmentsInput.value) filterAttachments(attachmentsInput.value);
+  if (imagesInput.value) filterImages(imagesInput.value);
+}
+
 // Start the popup.
 function start() {
   browser.storage.local.get("ticketStorage").then((data) => {
@@ -578,6 +687,9 @@ function start() {
 
     document.getElementById("loader").classList.remove("loading");
     document.getElementById("list-container-links").classList.remove("hidden");
+
+    // Re-apply any active search filters after content re-renders.
+    reapplySearchFilters();
   });
 }
 
@@ -676,6 +788,17 @@ document.addEventListener("DOMContentLoaded", () => {
     browser.runtime.openOptionsPage();
     window.close();
   });
+
+  // Dynamically retrieve the version number from manifest.json and link the
+  // gear-dropdown version item to the latest GitHub release.
+  const manifestData = browser.runtime.getManifest();
+  const version = manifestData.version;
+  const gearVersion = document.getElementById("gear-version");
+  gearVersion.textContent = `v${version}`;
+  gearVersion.setAttribute(
+    "href",
+    `https://github.com/bagtoad/zendesk-link-collector/releases/latest`
+  );
 
   // Event listener to copy summary to clipboard when summary button is clicked.
   document.getElementById("button-summary").addEventListener("click", () => {
@@ -800,17 +923,6 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   });
 
-  // Dynamically retrieve the version number from manifest.json and link the
-  // gear-dropdown version item to the latest GitHub release.
-  const manifestData = browser.runtime.getManifest();
-  const version = manifestData.version;
-  const gearVersion = document.getElementById("gear-version");
-  gearVersion.textContent = `v${version}`;
-  gearVersion.setAttribute(
-    "href",
-    `https://github.com/bagtoad/zendesk-link-collector/releases/latest`
-  );
-
   // Add event listeners for the new buttons to copy attachments and images in markdown format
   document
     .getElementById("button-copy-attachments-md")
@@ -818,4 +930,35 @@ document.addEventListener("DOMContentLoaded", () => {
   document
     .getElementById("button-copy-images-md")
     .addEventListener("click", copyImagesMarkdown);
+
+  // Live search: filter results as the user types.
+  document.getElementById("search-links").addEventListener("input", (e) => {
+    filterLinks(e.target.value);
+  });
+  document.getElementById("search-attachments").addEventListener("input", (e) => {
+    filterAttachments(e.target.value);
+  });
+  document.getElementById("search-images").addEventListener("input", (e) => {
+    filterImages(e.target.value);
+  });
+
+  // Clear search buttons: reset the input and show all items.
+  document.getElementById("clear-search-links").addEventListener("click", () => {
+    const input = document.getElementById("search-links");
+    input.value = "";
+    filterLinks("");
+    input.focus();
+  });
+  document.getElementById("clear-search-attachments").addEventListener("click", () => {
+    const input = document.getElementById("search-attachments");
+    input.value = "";
+    filterAttachments("");
+    input.focus();
+  });
+  document.getElementById("clear-search-images").addEventListener("click", () => {
+    const input = document.getElementById("search-images");
+    input.value = "";
+    filterImages("");
+    input.focus();
+  });
 });

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -648,9 +648,33 @@ document.addEventListener("DOMContentLoaded", () => {
       browser.runtime.openOptionsPage();
     });
 
-  // Event listener to open options when options button is clicked.
-  document.getElementById("button-options").addEventListener("click", () => {
+  // Event listener to toggle the gear dropdown when the gear icon is clicked.
+  const gearDropdown = document.getElementById("gear-dropdown");
+  document.getElementById("button-options").addEventListener("click", (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    gearDropdown.classList.toggle("open");
+  });
+
+  // Close the gear dropdown when clicking outside of it.
+  document.addEventListener("click", (e) => {
+    if (!gearDropdown.contains(e.target)) {
+      gearDropdown.classList.remove("open");
+    }
+  });
+
+  // Close the gear dropdown on Escape key.
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape") {
+      gearDropdown.classList.remove("open");
+    }
+  });
+
+  // Open the options page from within the gear dropdown.
+  document.getElementById("gear-options").addEventListener("click", (e) => {
+    e.preventDefault();
     browser.runtime.openOptionsPage();
+    window.close();
   });
 
   // Event listener to copy summary to clipboard when summary button is clicked.
@@ -776,14 +800,15 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   });
 
-  // Dynamically retrieve the version number from manifest.json and insert it into the "What's new?" button text.
+  // Dynamically retrieve the version number from manifest.json and link the
+  // gear-dropdown version item to the latest GitHub release.
   const manifestData = browser.runtime.getManifest();
   const version = manifestData.version;
-  const whatsNewButton = document.getElementById("button-whats-new");
-  whatsNewButton.textContent = `v${version}`;
-  whatsNewButton.setAttribute(
+  const gearVersion = document.getElementById("gear-version");
+  gearVersion.textContent = `v${version}`;
+  gearVersion.setAttribute(
     "href",
-    `https://github.com/bagtoad/zendesk-link-collector/releases/tag/v${version}`
+    `https://github.com/bagtoad/zendesk-link-collector/releases/latest`
   );
 
   // Add event listeners for the new buttons to copy attachments and images in markdown format


### PR DESCRIPTION
## Summary

Adds a typeahead search input + clear button on the right side of every sub-row (Links, Attachments, Images). As the user types, results filter in real time.

## Notes for reviewers

- **Depends on #85.** #85 moves the refresh + "What's New" buttons out of the links sub-row into the gear dropdown, freeing the right-side space this PR's search input occupies. Without #85 applied, the live-search input would collide with those existing buttons.
- One own commit (`17ec147`) on top of #85's tip, three files: `popup.html`, `popup.css`, `popup.js`. Because GitHub doesn't let cross-fork PRs base on a fork branch, the diff here also shows #85's commits; review only the top commit, or `git diff feature/gear-dropdown-and-search-squashed..feature/live-search`.
- Per-tab search keys:
  - Links — full visible row text (link text + context + date).
  - Attachments — file names; comment-group date also matches and reveals all its files.
  - Images — `img.alt` (file name).
- Group-aware hiding: Links headers (`h3`) and Attachments comment groups hide when none of their items match, so empty sections don't take vertical space.
- "No matches found." status div per tab; suppressed when the dataset is itself empty (the existing "not found" placeholder owns that case).
- Filters are re-applied after refresh re-renders the lists (`reapplySearchFilters()`).
- One small ancillary change in `displayImages`: it used to wipe `innerHTML`, which would also wipe the new "no matches" status div. It now removes only its own `ul.list-images`, matching what `displayLinks`/`displayAttachments` already do.
- Cross-browser: `appearance: none` + explicit `font-family`/`font-size` on the input and button so Chrome and Firefox render identical heights. Clear button shares `--gear-col-width` with the gear column above it.

## Test steps

1. `make dev`, load `build/firefox/manifest.json` as a Firefox temporary add-on and `build/chrome` as a Chrome unpacked extension. (Don't use `make build` for local testing — its artifacts use the release `gecko.id` and loading them can clobber your real `browser.storage` data.)
2. Open a Zendesk ticket with several links / attachments / images.
3. Type in the search box on each tab — items filter live; non-matching headers/groups hide.
4. Clear the input via the ⌫ button — all items return; focus returns to the input.
5. Type a query that matches nothing — "No matches found." appears.
6. Refresh the popup with an active query — results stay filtered after re-render.
