### PR TITLE
chore: add 'make dev' target for safe local testing

### DIFF
--- a/makefile
+++ b/makefile
@@ -13,11 +13,22 @@ CP = cp -r
 MV = mv
 WE = web-ext
 
-.PHONY: all clean firefox chrome build lint
+# Gecko extension IDs
+# Release ID is the store-published ID (in manifest-firefox.json source).
+# Dev ID is used for local testing to avoid sharing storage with the store version.
+GECKO_RELEASE_ID = {e4a90df4-3bc1-11ee-be56-0242ac120002}
+GECKO_DEV_ID = {94a27906-e3da-4252-8e5e-402092f8d9aa}
 
-# Build with web-ext
+.PHONY: all clean firefox chrome build lint dev swap-gecko-dev build-firefox-dev
+
+# Build with web-ext (release — uses the store gecko ID)
 all: prep-firefox prep-chrome build-firefox build-chrome
 build: all
+
+# Build for local dev/testing (uses a separate gecko ID to protect store data).
+# Real prerequisites are declared on swap-gecko-dev and build-firefox-dev so
+# `make -j dev` can't reorder these steps and ship a release-ID artifact.
+dev: prep-chrome build-firefox-dev build-chrome
 
 # Lint with web-ext
 lint: prep-firefox prep-chrome lint-firefox lint-chrome
@@ -36,12 +47,27 @@ prep-chrome:
 	$(MV) $(CHROME_BUILD_DIR)/manifest-chrome.json $(CHROME_BUILD_DIR)/manifest.json
 	$(RM) $(CHROME_BUILD_DIR)/manifest-firefox.json
 
+# Swap the gecko ID to the dev ID in the Firefox build (for safe local testing).
+# Depends on prep-firefox so under `make -j` the manifest exists before sed runs.
+# Uses a temp file instead of sed -i for macOS/BSD portability.
+swap-gecko-dev: prep-firefox
+	sed 's/$(GECKO_RELEASE_ID)/$(GECKO_DEV_ID)/' $(FIREFOX_BUILD_DIR)/manifest.json > $(FIREFOX_BUILD_DIR)/manifest.json.tmp
+	$(MV) $(FIREFOX_BUILD_DIR)/manifest.json.tmp $(FIREFOX_BUILD_DIR)/manifest.json
+	@grep -q '$(GECKO_DEV_ID)' $(FIREFOX_BUILD_DIR)/manifest.json || \
+		(echo "ERROR: dev gecko ID not present after swap. GECKO_RELEASE_ID in this makefile ($(GECKO_RELEASE_ID)) likely no longer matches manifest-firefox.json — update it." >&2; exit 1)
+
 # Build for Firefox with web-ext
 build-firefox:
 	$(WE) build --source-dir=$(FIREFOX_BUILD_DIR) --artifacts-dir=$(FIREFOX_BUILD_DIR)/artifacts
 
-# Build for Chrome with web-ext
-build-chrome:
+# Dev variant: gated on swap-gecko-dev so the artifact always carries the
+# dev ID, even under `make -j`. Release builds keep using build-firefox.
+build-firefox-dev: swap-gecko-dev
+	$(WE) build --source-dir=$(FIREFOX_BUILD_DIR) --artifacts-dir=$(FIREFOX_BUILD_DIR)/artifacts
+
+# Build for Chrome with web-ext. Depends on prep-chrome so under `make -j`
+# the Chrome build dir is fully populated before web-ext starts.
+build-chrome: prep-chrome
 	$(WE) build --source-dir=$(CHROME_BUILD_DIR) --artifacts-dir=$(CHROME_BUILD_DIR)/artifacts
 
 # Lint for Firefox with web-ext


### PR DESCRIPTION
## Summary

Adds a `make dev` build target that swaps the Firefox gecko extension ID
from the store-published ID to a separate dev ID before building. This
protects a contributor's real add-on data while testing an unpacked
build, since Firefox keys `storage.sync` per gecko ID.

## Notes for reviewers

One commit to `makefile`. The branch went through a few iterations
during review (race-fix and drift-assertion landed as follow-up
commits); those have been squashed into the single commit below.

**`f4fb6c7` chore: add 'make dev' target for safe local testing**

Three concerns wired up:

- **Dev gecko-ID swap (Firefox).** New `swap-gecko-dev` target uses
  `sed` (with a temp file + `mv`, portable across GNU/BSD) to replace
  `GECKO_RELEASE_ID` with `GECKO_DEV_ID` in the built manifest, leaving
  `src/manifest-firefox.json` untouched.
- **`-j` correctness.** The `dev` target's data dependencies are
  expressed as recipe prereqs so `make -j dev` can't reorder them:
  `swap-gecko-dev: prep-firefox` (sed needs the manifest first),
  `build-firefox-dev: swap-gecko-dev` (the dev XPI must be the
  swapped one), and `build-chrome: prep-chrome` (`web-ext build` needs
  a populated `build/chrome/` to package).
- **Drift assertion.** `GECKO_RELEASE_ID` in the makefile is a
  hand-maintained copy of the ID in `manifest-firefox.json`. If the
  manifest's ID is ever bumped without updating the makefile, sed
  silently does nothing and the dev build ships the release ID — the
  exact failure this target prevents. After the swap, `grep` for the
  dev ID and fail loudly with a pointer at `GECKO_RELEASE_ID` if it
  isn't there.

`make build` is unchanged — release builds still use the store ID and
source `manifest-firefox.json` is never modified.

Dev ID: `{94a27906-e3da-4252-8e5e-402092f8d9aa}` (random UUID, not
registered with AMO).

## Test steps

1. `make build` → `build/firefox/manifest.json` shows the store ID.
   (Unchanged behavior.)
2. `make dev` → `build/firefox/manifest.json` shows the dev ID. Source
   `src/manifest-firefox.json` still shows the store ID.
3. `make -j dev` (parallel) → also produces a dev-ID artifact and a
   fully-populated Chrome build dir; previously could ship release ID
   on Firefox or `web-ext build` an empty Chrome dir.
4. Drift check: temporarily edit `GECKO_RELEASE_ID` in `makefile` to a
   value that doesn't appear in `manifest-firefox.json`, run `make dev`
   → fails loudly with the assertion error. Revert.
5. Load the dev XPI in Firefox and observe it lives in its own
   `storage.sync` bucket separate from any AMO-installed copy.
