### PR TITLE
chore: drop unnecessary backslash-dash escapes in Zendesk URL regex

### DIFF
--- a/src/background/background.js
+++ b/src/background/background.js
@@ -460,7 +460,7 @@ browser.tabs.onActivated.addListener((activeTab) => {
     if (
       !tab.url ||
       tab.url.search(
-        /^https:\/\/[\-_A-Za-z0-9]+\.zendesk.com\/agent\/tickets\/[0-9]+/i
+        /^https:\/\/[-_A-Za-z0-9]+\.zendesk.com\/agent\/tickets\/[0-9]+/i
       ) == -1
     ) {
       browser.action.disable(tab.id);
@@ -492,7 +492,7 @@ browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
   if (
     !tab.url ||
     tab.url.search(
-      /^https:\/\/[\-_A-Za-z0-9]+\.zendesk.com\/agent\/tickets\/[0-9]+/i
+      /^https:\/\/[-_A-Za-z0-9]+\.zendesk.com\/agent\/tickets\/[0-9]+/i
     ) == -1
   ) {
     browser.action.disable(tab.id);


### PR DESCRIPTION
## Summary

A leading `-` inside a character class is already literal, so `[\-_A-Za-z0-9]` and `[-_A-Za-z0-9]` match identically. Removing the escape silences ESLint's `no-useless-escape` and keeps the regex behavior unchanged.

## Why

This is the only `no-useless-escape` warning in the codebase. Landing this on its own clears the path for #106, which adds ESLint to CI — once #106 lands, this would otherwise be a CI failure on day one.

## Notes for reviewers

One commit, one regex.

**`08db511` chore: drop unnecessary backslash-dash escapes in Zendesk URL regex** — `background.js` only. The pattern matches the same set of strings before and after; the only difference is ESLint's view of it.

## Test steps

The regex pattern is unchanged in behavior. Existing Zendesk-URL detection in `background.js` continues to match the same set of strings.

