### PR TITLE
refactor: use optional catch binding in RegExp validation

### DIFF
--- a/src/options/options.js
+++ b/src/options/options.js
@@ -147,7 +147,7 @@ function saveLinkPatterns() {
     // Validate RegEx.
     try {
       new RegExp(document.getElementById("pattern").value);
-    } catch (SyntaxError) {
+    } catch {
       setLinkPatternError(
         "Invalid RegEx pattern! - Great work! That's difficult to do! :D"
       );
@@ -280,7 +280,7 @@ function updateLinkPattern() {
       // Validate RegEx.
       try {
         new RegExp(document.getElementById("pattern").value);
-      } catch (SyntaxError) {
+      } catch {
         setLinkPatternError(
           "Invalid RegEx pattern! - Great work! That's difficult to do! :D"
         );
@@ -392,7 +392,7 @@ function importLinkPatternsJSON() {
       // Validate RegEx.
       try {
         new RegExp(option.pattern);
-      } catch (SyntaxError) {
+      } catch {
         console.error("Invalid JSON data (bad pattern)");
         return;
       }


### PR DESCRIPTION
Cleans up three `try { new RegExp(...) } catch (SyntaxError) { ... }` blocks in `src/options/options.js` (RegExp validation when adding/editing a link pattern, and when importing options JSON).

## Why

`catch (name)` always catches everything that's thrown — `name` is just a binding for the caught value, **not** a type filter. The current `catch (SyntaxError)` reads as if it filters by type but doesn't, and it shadows the global `SyntaxError` constructor inside the catch block.

ES2019 optional catch binding (`} catch {`) drops the unused, misleading binding entirely. Cleaner read and no shadowing.

## Notes for reviewers

Single commit, one file, three identical edits. Behavior unchanged — bad RegExp input still surfaces the same user-facing error.

## Test steps

- Open the options page, add a link with an invalid RegExp pattern (e.g. `[`) → "Invalid RegEx pattern!" message still appears.
- Import an options JSON file containing an invalid pattern → still rejected with the same console error.

## Context

Surfaced as one of the follow-up findings in #92 (ESLint CI). Independent of that PR — can land in either order.
