### PR TITLE
feat(options): redesign options page with sectioned layout, inline editing, and tooltips

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,14 @@
 # ZLC Specific
 build
 
+# Local config backups (never commit — contains personal patterns)
+zlc-config*.json
+zlc-patterns*.json
+
+# Dependencies (installed locally if running ESLint by hand;
+# CI installs inline so the repo never tracks them)
+node_modules
+
 # General
 .DS_Store
 .AppleDouble
@@ -27,3 +35,6 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdisk
+
+# Design preview sandbox (never commit)
+design-previews/

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -359,6 +359,15 @@ select {
 }
 
 .form-actions { margin-top: var(--s-4); }
+/* Submit button living inside .form-grid--inline (flex row): pushes
+   itself to the right edge so it shares the row with the toggles
+   instead of taking its own line below. The extra margin-top nudges
+   it lower than its row siblings so it doesn't crowd the Pattern
+   input above. */
+.form-inline-submit {
+    margin-left: auto;
+    margin-top: var(--s-4);
+}
 .form-actions--end {
     display: flex;
     justify-content: flex-end;

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -15,6 +15,7 @@
     --panel:         rgb(33, 38, 45);
     --panel-2:       rgb(40, 46, 54);
     --border:        rgb(55, 62, 71);
+    --border-soft:   rgb(48, 54, 61);
     --border-2:      rgb(73, 82, 94);
     --text:          rgb(201, 209, 217);
     --text-strong:   rgb(240, 246, 252);
@@ -44,15 +45,18 @@
 html, body { margin: 0; padding: 0; }
 
 body {
-    /* Subtle radial tint at the top gives the page a touch of warmth without
-       distracting from content. */
+    /* Top-left radial flare + a vertical gradient from near-black at the
+       top into the body color. Gives the page a warmer, more human feel
+       than a centered top tint — the light source is anchored to the
+       upper-left corner. */
     background:
-        radial-gradient(circle at 50% -10%, rgba(56, 139, 253, 0.10), transparent 40rem),
-        var(--bg);
+        radial-gradient(circle at top left, rgba(56, 139, 253, 0.12), transparent 24rem),
+        linear-gradient(180deg, rgb(13, 17, 23), var(--bg) 14rem);
     color: var(--text);
-    font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-    font-size: 14px;
-    line-height: 1.5;
+    /* 1rem/1.45 matches the B-console mock: slightly larger and airier than
+       the previous 14px/1.5. Specific font sizes elsewhere (table cells,
+       eyebrow, etc.) are explicit so they don't shift with this baseline. */
+    font: 1rem/1.45 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
     color-scheme: dark;
     accent-color: var(--accent);
     min-height: 100vh;
@@ -85,13 +89,24 @@ code, kbd, pre, .mono {
 }
 .eyebrow {
     margin: 0 0 var(--s-2);
-    color: var(--muted);
+    color: var(--accent);
     font-size: 12px;
-    letter-spacing: 0.06em;
+    font-weight: 700;
+    letter-spacing: 0.08em;
     text-transform: uppercase;
 }
-.page-header h1 { font-size: 28px; }
-.lede { margin: var(--s-2) 0 0; color: var(--muted); max-width: 64ch; }
+.page-header h1 {
+    margin: 0 0 var(--s-2);
+    font-size: clamp(2rem, 5vw, 3.25rem);
+    line-height: 1;
+    color: var(--text-strong);
+}
+.lede {
+    margin: var(--s-2) 0 0;
+    color: var(--muted);
+    font-size: 1.05rem;
+    max-width: 64ch;
+}
 
 /* Main column of section cards. */
 main.shell {
@@ -100,16 +115,19 @@ main.shell {
     gap: var(--s-6);
 }
 
-/* Section card — the section element itself is the panel. */
+/* Section card — the section element itself is the panel. Mirrors the
+   B-console preview: subtle vertical gradient on the panel color, soft
+   border, lifted with a low-spread shadow, 12px corner radius. */
 .section {
-    background: var(--panel);
+    background: linear-gradient(180deg, var(--panel), rgb(28, 33, 40));
     border: 1px solid var(--border);
-    border-radius: var(--radius);
+    border-radius: 12px;
+    box-shadow: 0 12px 28px rgb(0 0 0 / 0.18);
     padding: var(--s-5);
 }
 .section__head { margin-bottom: var(--s-4); }
-.section__head h2 { font-size: 16px; }
-.section__head p { margin: var(--s-1) 0 0; color: var(--muted); font-size: 13px; }
+.section__head h2 { font-size: 1.15rem; }
+.section__head p { margin: var(--s-1) 0 0; color: var(--muted); font-size: 0.88rem; }
 
 /* Stack of subcards inside a section. */
 .stack { display: flex; flex-direction: column; gap: var(--s-4); }
@@ -126,7 +144,7 @@ main.shell {
    the card border. The title still gets its own padding. */
 .subcard--flush { padding: 0; overflow: hidden; }
 .subcard__title {
-    font-size: 14px;
+    font-size: 1rem;
     font-weight: 600;
     margin-bottom: var(--s-3);
 }

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -365,17 +365,31 @@ select {
     gap: var(--s-2);
 }
 
-/* Error banner — shown below the add-pattern form when validation fails. */
+/* Error banner — shown below the add-pattern form when validation fails.
+   Sized small so it doesn't dominate the section. Section-level alerts
+   reserve their slot when empty (see the .hidden override below) so that
+   toggling the message doesn't shift the surrounding layout. */
 .alert {
-    margin-top: var(--s-3);
+    margin-top: var(--s-2);
     background: var(--danger-bg);
     color: var(--danger-fg);
     border: 1px solid rgba(248, 81, 73, 0.3);
     border-radius: var(--radius);
-    padding: var(--s-2) var(--s-3);
+    padding: var(--s-1) var(--s-2);
     font-size: 13px;
+    line-height: 1.4;
 }
 .hidden { display: none; }
+
+/* Slot reservation for section-level alerts only. The row-edit error has
+   its own slot-reservation strategy via the flex stack inside the pattern
+   cell — see .row-edit-pattern-stack below. Other .hidden consumers (image
+   tab toggles, etc.) are unaffected. */
+#link-patterns-error.hidden,
+#link-patterns-io-status.hidden {
+    visibility: hidden;
+    display: block;
+}
 
 /*
  * Tables — shared between the Examples sub-card and the Rules sub-card so
@@ -447,6 +461,33 @@ table#table-link-patterns tr.editing td.cell--pattern input[type="text"] {
     font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
 }
 
+/* The pattern cell uses a fixed-height vertical flex stack so the input
+   stays centered when there's no error and visibly slides up when the
+   error appears beneath it — without changing the cell's overall height.
+   td-as-flex is unreliable cross-browser, so the stack lives in a wrapper
+   div appended in editLinkPatternInline. */
+.row-edit-pattern-stack {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: var(--s-1);
+    min-height: 60px;
+}
+table#table-link-patterns tr.editing td.cell--pattern {
+    vertical-align: middle;
+}
+
+/* Row-local validation error — matches the pattern input's metrics
+   (padding, font-size, line-height, mono font) so the two boxes read as
+   the same shape; only the red colors from .alert distinguish them. */
+table#table-link-patterns tr.editing .row-edit-error {
+    margin-top: 0;
+    padding: 4px 8px;
+    font-size: 13px;
+    line-height: 1.4;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
 /* Rules table specifics — hover, edit-row wash, action buttons. */
 /* Fixed layout + colgroup so the Pattern column gets the leftover width
    and small action columns stay narrow, regardless of cell content width. */
@@ -464,6 +505,12 @@ table#table-link-patterns th,
 table#table-link-patterns td {
     padding: var(--s-2);
     overflow: hidden;
+}
+/* Pre-size every body row so toggling the inline-edit error never changes
+   the row's outer height. 60px fits input + gap + error; with td padding
+   this matches the editing-with-error state. */
+table#table-link-patterns tbody td {
+    height: 60px;
 }
 table#table-link-patterns td.cell--pattern pre {
     white-space: pre-wrap;

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -135,42 +135,24 @@ main.shell {
     margin-bottom: var(--s-3);
 }
 
-/* Globals: 2-column grid of toggle rows. */
-.globals {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: var(--s-3) var(--s-5);
-}
+/*
+ * Toggle row: one flex line of [checkbox][label][?]. Single primitive,
+ * used identically in the global-settings grid and in the pattern form.
+ *
+ * The 2-column grid for globals is on the parent (.toggle-list--grid).
+ * No nested grids, no display:contents — keeping this primitive flat is
+ * the whole point of the recent simplification.
+ */
 .toggle-row {
-    display: grid;
-    grid-template-columns: 18px auto 1fr;
-    gap: var(--s-3);
-    align-items: start;
-    padding: var(--s-2) 0;
-}
-/* Inline variant used inside the pattern form (no description). */
-.toggle-row--inline {
-    grid-template-columns: 18px auto auto;
+    display: flex;
     align-items: center;
-    padding: 0;
+    gap: var(--s-2);
+    padding: var(--s-1) 0;
 }
 .toggle-row__label {
     font-weight: 600;
     cursor: pointer;
     color: var(--text-strong);
-}
-/* Bigger, more legible label for the global-settings toggles where the
-   row is the entire piece of UI (no description text below). */
-.toggle-row__label--lg {
-    font-size: 16px;
-    line-height: 1.3;
-}
-/* Description sits on the panel background — keep it close to body text
-   color so it's comfortably readable, just one shade down from the label. */
-.toggle-row__desc {
-    color: var(--text);
-    font-size: 13px;
-    line-height: 1.45;
 }
 
 /* Form label with an inline help button next to it (e.g. "Summary type ?"). */
@@ -180,26 +162,13 @@ main.shell {
     gap: var(--s-1);
 }
 
-/* Two-column layout for global-settings toggles. Each column is its own
-   3-track grid (☐ label ?) so `auto` sizing makes the ?'s align right
-   after the column's longest label — a per-column tab stop. */
+/* Two-column layout for the global-settings toggles. Each cell is just a
+   .toggle-row — same primitive used everywhere else. */
 .toggle-list--grid {
     display: grid;
     grid-template-columns: 1fr 1fr;
     gap: var(--s-3) var(--s-6);
 }
-.toggle-col {
-    display: grid;
-    grid-template-columns: 18px auto auto;
-    align-content: start;
-    justify-self: start;
-    row-gap: var(--s-3);
-    column-gap: var(--s-3);
-}
-.toggle-list--grid .toggle-row--inline {
-    display: contents;
-}
-.toggle-list--grid .help-tip { margin-left: 0; }
 
 /* Custom-styled checkboxes — consistent across browsers, accent-filled when
    checked. Used for both global toggles and the disabled checkboxes in the

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -574,9 +574,7 @@ input[type="radio"]:checked::after {
 
 /* Narrow-viewport collapse: 2-col grids drop to one column. */
 @media (max-width: 720px) {
-    .globals { grid-template-columns: 1fr; }
     .form-grid,
-    .form-grid--three,
     .form-grid--title-pattern,
     .toggle-list--grid { grid-template-columns: 1fr; }
     .io-row__buttons { margin-left: 0; }

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -1,121 +1,596 @@
+/*
+ * Options page styles.
+ *
+ * Structure: a centered 1024px shell. Each top-level <section> IS the card —
+ * background, border, padding — with its heading inside. Patterns section
+ * nests subcards in a .stack for the add-form, examples table, and rules table.
+ *
+ * Tokens live on :root so a future light theme can swap them in one place.
+ */
+
+:root {
+    /* Palette — matches the popup window's dark colors with a warmer accent. */
+    --bg:            rgb(22, 27, 34);
+    --bg-deep:       rgb(13, 17, 23);
+    --panel:         rgb(33, 38, 45);
+    --panel-2:       rgb(40, 46, 54);
+    --border:        rgb(55, 62, 71);
+    --border-2:      rgb(73, 82, 94);
+    --text:          rgb(201, 209, 217);
+    --text-strong:   rgb(240, 246, 252);
+    --muted:         rgb(139, 148, 158);
+    --accent:        rgb(98, 163, 75);
+    --accent-hover:  rgb(118, 183, 95);
+    --accent-text:   rgb(218, 251, 225);
+    --danger-bg:     rgba(248, 81, 73, 0.12);
+    --danger-fg:     rgb(248, 81, 73);
+    --focus:         rgb(88, 166, 255);
+    --row-editing:   rgba(98, 163, 75, 0.10);
+
+    /* Spacing scale (4px base). */
+    --s-1: 4px;
+    --s-2: 8px;
+    --s-3: 12px;
+    --s-4: 16px;
+    --s-5: 24px;
+    --s-6: 32px;
+    --s-7: 48px;
+
+    --radius: 8px;
+    --shell-max: 1024px;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+
 body {
-    font-family: sans-serif;
-    color: rgb(201, 209, 217);
-    background-color: rgb(22, 27, 34);
+    /* Subtle radial tint at the top gives the page a touch of warmth without
+       distracting from content. */
+    background:
+        radial-gradient(circle at 50% -10%, rgba(56, 139, 253, 0.10), transparent 40rem),
+        var(--bg);
+    color: var(--text);
+    font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    font-size: 14px;
+    line-height: 1.5;
     color-scheme: dark;
+    accent-color: var(--accent);
+    min-height: 100vh;
+    padding-bottom: var(--s-7);
 }
 
-/* Generic Input Styles */
-button:hover,
-input[type="checkbox"]:enabled:hover,
-input[type="file"],
-input[type=file]::-webkit-file-upload-button,
-select {
-    /* Found solution for "Choose File" button not applying styles here:
-    https://stackoverflow.com/questions/1537223/change-cursor-type-on-input-type-file */
-    cursor: pointer;
-    background-color: rgb(39, 44, 51);
+h1, h2, h3 { margin: 0; color: var(--text-strong); font-weight: 600; }
+.muted { color: var(--muted); font-weight: 400; }
+
+code, kbd, pre, .mono {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
 }
 
-button {
-    border-radius: 4px;
-    padding: 2px 12px;
-    background-color: rgb(33, 38, 45);
-    border-color: rgba(240, 246, 252, 0.1);
-    color: rgb(201, 209, 217);
+/* Visible focus ring across the page. */
+:focus-visible {
+    outline: 2px solid var(--focus);
+    outline-offset: 2px;
 }
 
-button:disabled {
-    background-color: rgb(39, 44, 51);
-    color: rgb(148 147 147);
+/* Centered shell, reused by header + main. */
+.shell {
+    max-width: var(--shell-max);
+    margin: 0 auto;
+    padding: 0 var(--s-5);
 }
 
-button:disabled:hover {
-    cursor: not-allowed;
+/* Page header. Lives above the section cards. */
+.page-header {
+    padding: var(--s-7) 0 var(--s-5);
 }
-
-.input-label {
-    position: relative;
-  }
-  
-.input-label::after {
-    content: "?";
-    position: absolute;
-    top: -15px;
-    left: -8px;
-    width: 15px;
-    height: 15px;
-    border-radius: 50%;
-    background-color: rgb(148 147 147);
-    color: white;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    cursor: help;
+.eyebrow {
+    margin: 0 0 var(--s-2);
+    color: var(--muted);
+    font-size: 12px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
 }
+.page-header h1 { font-size: 28px; }
+.lede { margin: var(--s-2) 0 0; color: var(--muted); max-width: 64ch; }
 
-.input-container-column {
+/* Main column of section cards. */
+main.shell {
     display: flex;
     flex-direction: column;
+    gap: var(--s-6);
 }
 
-.input-container-row [type="text"] {
-    width: 200px;
+/* Section card — the section element itself is the panel. */
+.section {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: var(--s-5);
+}
+.section__head { margin-bottom: var(--s-4); }
+.section__head h2 { font-size: 16px; }
+.section__head p { margin: var(--s-1) 0 0; color: var(--muted); font-size: 13px; }
+
+/* Stack of subcards inside a section. */
+.stack { display: flex; flex-direction: column; gap: var(--s-4); }
+
+/* Subcard — nested panel inside a section. Slightly lighter than the
+   parent .section so it reads as raised, not sunken. */
+.subcard {
+    background: var(--panel-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: var(--s-4);
+}
+/* "Flush" variant: tables sit edge-to-edge so column borders line up with
+   the card border. The title still gets its own padding. */
+.subcard--flush { padding: 0; overflow: hidden; }
+.subcard__title {
+    font-size: 14px;
+    font-weight: 600;
+    margin-bottom: var(--s-3);
+}
+.subcard__title--padded {
+    padding: var(--s-3) var(--s-4) 0;
+    margin-bottom: var(--s-3);
 }
 
-.input-container-row label {
-    font-weight: bold;
-    margin: 0 2px 0 15px;
+/* Globals: 2-column grid of toggle rows. */
+.globals {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--s-3) var(--s-5);
+}
+.toggle-row {
+    display: grid;
+    grid-template-columns: 18px auto 1fr;
+    gap: var(--s-3);
+    align-items: start;
+    padding: var(--s-2) 0;
+}
+/* Inline variant used inside the pattern form (no description). */
+.toggle-row--inline {
+    grid-template-columns: 18px auto auto;
+    align-items: center;
+    padding: 0;
+}
+.toggle-row__label {
+    font-weight: 600;
+    cursor: pointer;
+    color: var(--text-strong);
+}
+/* Bigger, more legible label for the global-settings toggles where the
+   row is the entire piece of UI (no description text below). */
+.toggle-row__label--lg {
+    font-size: 16px;
+    line-height: 1.3;
+}
+/* Description sits on the panel background — keep it close to body text
+   color so it's comfortably readable, just one shade down from the label. */
+.toggle-row__desc {
+    color: var(--text);
+    font-size: 13px;
+    line-height: 1.45;
 }
 
-.input-container-row label:first-child {
-    margin-left: 0;
+/* Form label with an inline help button next to it (e.g. "Summary type ?"). */
+.label-with-help {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--s-1);
 }
 
-.input-container-row {
-    margin-bottom: 15px;
+/* Two-column layout for global-settings toggles. Each column is its own
+   3-track grid (☐ label ?) so `auto` sizing makes the ?'s align right
+   after the column's longest label — a per-column tab stop. */
+.toggle-list--grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--s-3) var(--s-6);
+}
+.toggle-col {
+    display: grid;
+    grid-template-columns: 18px auto auto;
+    align-content: start;
+    justify-self: start;
+    row-gap: var(--s-3);
+    column-gap: var(--s-3);
+}
+.toggle-list--grid .toggle-row--inline {
+    display: contents;
+}
+.toggle-list--grid .help-tip { margin-left: 0; }
+
+/* Custom-styled checkboxes — consistent across browsers, accent-filled when
+   checked. Used for both global toggles and the disabled checkboxes in the
+   rules table. */
+input[type="checkbox"] {
+    appearance: none;
+    -webkit-appearance: none;
+    width: 18px;
+    height: 18px;
+    margin: 2px 0 0;
+    background: var(--panel-2);
+    border: 1px solid var(--border-2);
+    border-radius: 4px;
+    cursor: pointer;
+    position: relative;
+    flex-shrink: 0;
+}
+input[type="checkbox"]:checked {
+    background: var(--accent);
+    border-color: var(--accent);
+}
+input[type="checkbox"]:checked::after {
+    content: "✓";
+    position: absolute;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    color: var(--text-strong);
+    font-size: 13px;
+    line-height: 1;
+}
+input[type="checkbox"]:disabled {
+    cursor: default;
+    opacity: 0.85;
 }
 
-.input-container-row {
+/* Form controls. */
+label { font-size: 13px; color: var(--text); }
+input[type="text"],
+input[type="file"],
+select {
+    appearance: none;
+    -webkit-appearance: none;
+    background: var(--panel-2);
+    color: var(--text);
+    border: 1px solid var(--border-2);
+    border-radius: var(--radius);
+    padding: 7px 10px;
+    font: inherit;
+    width: 100%;
+}
+input[type="text"]:focus, select:focus { border-color: var(--focus); outline: none; }
+input[type="text"].mono {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+input[type="file"] { padding: 5px; cursor: pointer; }
+select {
+    cursor: pointer;
+    padding-right: 28px;
+    /* Inline caret so we don't depend on platform select rendering. */
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'><path fill='%238b949e' d='M2 4l4 4 4-4z'/></svg>");
+    background-repeat: no-repeat;
+    background-position: right 10px center;
+}
+
+.form-row { display: flex; flex-direction: column; gap: var(--s-1); min-width: 0; }
+.form-grid {
+    display: grid;
+    gap: var(--s-4);
+    grid-template-columns: 1fr 1fr;
+}
+.form-grid + .form-grid,
+.form-grid + .form-grid--inline,
+.form-grid--inline + .form-grid,
+.form-grid--inline + .form-grid--inline { margin-top: var(--s-4); }
+/* Title is short ("GitHub Docs"); Pattern is long. Give Pattern ~3x the
+   width so most regexes don't wrap or look cramped. */
+.form-grid--title-pattern { grid-template-columns: minmax(160px, 1fr) 3fr; }
+
+/* Compact second row: Summary type select + the Show context / Show date
+   toggles all on one inline row. The Summary type label sits to the left of
+   its select (instead of stacked above it) so it aligns with the toggles. */
+.form-grid--inline {
     display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--s-5);
+}
+.form-row--compact {
+    flex: 0 0 auto;
     flex-direction: row;
     align-items: center;
+    gap: var(--s-2);
+}
+.form-row--compact select { width: auto; min-width: 110px; }
+
+/* Inline help button: a small "?" with a description in both `title`
+   (mouse hover) and `aria-label` (screen readers). It's a real <button>
+   so keyboard users can focus and read it. */
+.help-tip {
+    appearance: none;
+    -webkit-appearance: none;
+    margin-left: var(--s-1);
+    width: 18px;
+    height: 18px;
+    padding: 0;
+    border: 1px solid var(--border);
+    border-radius: 50%;
+    background: var(--panel-2);
+    color: var(--muted);
+    font-size: 11px;
+    line-height: 1;
+    font-weight: 600;
+    cursor: help;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+.help-tip:hover,
+.help-tip:focus-visible {
+    color: var(--text-strong);
+    border-color: var(--accent);
+    outline: none;
 }
 
-.input-container-row * {
-    margin: 0 5px;
+
+/* Buttons. */
+.btn {
+    appearance: none;
+    -webkit-appearance: none;
+    background: var(--panel-2);
+    color: var(--text);
+    border: 1px solid var(--border-2);
+    border-radius: var(--radius);
+    padding: 7px 14px;
+    font: inherit;
+    font-weight: 500;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: var(--s-1);
+}
+.btn:hover { background: var(--border); }
+.btn--primary {
+    background: var(--accent);
+    border-color: var(--accent);
+    /* Light-green tinted text reads as on-brand without the harshness of pure
+       white on the green field. */
+    color: var(--accent-text);
+}
+.btn--primary:hover {
+    background: var(--accent-hover);
+    border-color: var(--accent-hover);
+}
+.btn--ghost { background: transparent; }
+.btn--small { padding: 4px 10px; font-size: 12px; }
+/* Visually-invalid state for action buttons (e.g. Save with a bad regex).
+   We don't disable the button — clicking it still shows the inline error —
+   but red signals "this won't succeed yet". */
+.btn--invalid,
+.btn--invalid:hover {
+    background: var(--danger-bg);
+    border-color: var(--danger-fg);
+    color: var(--danger-fg);
+}
+.btn:disabled,
+.btn[disabled] {
+    cursor: not-allowed;
+    opacity: 0.6;
 }
 
-#link-patterns-error {
-    background-color: rgb(179 0 0 / 18%);
-    padding: 10px;
-    border: 2px solid rgb(179 0 0 / 18%);
+.form-actions { margin-top: var(--s-4); }
+.form-actions--end {
+    display: flex;
+    justify-content: flex-end;
+    gap: var(--s-2);
 }
 
-.hidden {
-    display: none;
+/* Error banner — shown below the add-pattern form when validation fails. */
+.alert {
+    margin-top: var(--s-3);
+    background: var(--danger-bg);
+    color: var(--danger-fg);
+    border: 1px solid rgba(248, 81, 73, 0.3);
+    border-radius: var(--radius);
+    padding: var(--s-2) var(--s-3);
+    font-size: 13px;
 }
+.hidden { display: none; }
 
-/* Table Styles */
-table#table-link-patterns {
+/*
+ * Tables — shared between the Examples sub-card and the Rules sub-card so
+ * the user learns the columns once. The .data-table class provides shared
+ * header/cell styling; #table-link-patterns adds row-edit affordances.
+ */
+.data-table {
+    width: 100%;
     border-collapse: collapse;
 }
-
-table#table-link-patterns td, table#table-link-patterns th {
-    border: 1px solid rgb(201, 209, 217);
+.data-table th,
+.data-table td {
+    padding: var(--s-2) var(--s-3);
+    border-bottom: 1px solid var(--border);
     text-align: center;
+    vertical-align: middle;
+}
+.data-table th {
+    background: var(--panel-2);
+    color: var(--muted);
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.5px;
+    text-transform: uppercase;
+    border-bottom: 1px solid var(--border-2);
+}
+.data-table th:first-child,
+.data-table td:first-child {
+    text-align: left;
+}
+.data-table tbody tr:last-child td { border-bottom: none; }
+/* Inline form controls inside table cells (used in the examples table)
+   shouldn't stretch to fill the cell — let them size to content. */
+.data-table td input[type="checkbox"] {
+    margin: 0;
+    vertical-align: middle;
+}
+.data-table td select {
+    width: auto;
+    min-width: 90px;
+    padding: 4px 24px 4px 8px;
+    font-size: 12px;
+    background-position: right 6px center;
+}
+.data-table td.cell--pattern {
+    text-align: left;
+}
+.data-table td.cell--pattern code,
+.data-table td pre {
+    font-size: 13px;
+    color: var(--text);
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    white-space: pre-wrap;
+    word-break: break-all;
+}
+.data-table td pre { margin: 0; }
+/* Boolean cells: muted "No" by default; green "Yes" reads the accent color
+   and gives the table a touch of green without being noisy. */
+.data-table td.cell--bool { color: var(--muted); font-size: 12px; }
+.data-table td.cell--bool.is-yes { color: var(--accent-hover); font-weight: 500; }
+
+/* Inline-edit row: text inputs fill their cell so editing feels in place. */
+table#table-link-patterns tr.editing td input[type="text"] {
+    width: 100%;
+    padding: 4px 8px;
+    font-size: 13px;
+}
+table#table-link-patterns tr.editing td.cell--pattern input[type="text"] {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
 }
 
+/* Rules table specifics — hover, edit-row wash, action buttons. */
+/* Fixed layout + colgroup so the Pattern column gets the leftover width
+   and small action columns stay narrow, regardless of cell content width. */
+table#table-link-patterns {
+    width: 100%;
+    table-layout: fixed;
+}
+table#table-link-patterns col.col-title    { width: 14%; }
+table#table-link-patterns col.col-pattern  { width: auto; }
+table#table-link-patterns col.col-bool     { width: 64px; }
+table#table-link-patterns col.col-summary  { width: 76px; }
+table#table-link-patterns col.col-reorder  { width: 56px; }
+table#table-link-patterns col.col-action   { width: 48px; }
+table#table-link-patterns th,
 table#table-link-patterns td {
-    padding: 5px 10px;
+    padding: var(--s-2);
+    overflow: hidden;
+}
+table#table-link-patterns td.cell--pattern pre {
+    white-space: pre-wrap;
+    word-break: break-all;
+    max-width: 100%;
+    margin: 0;
+}
+table#table-link-patterns tbody tr:hover {
+    background: rgba(255, 255, 255, 0.02);
+}
+table#table-link-patterns tbody tr.editing,
+table#table-link-patterns tbody tr.editing:hover {
+    background: var(--row-editing);
+}
+table#table-link-patterns td button {
+    background: var(--panel-2);
+    color: var(--text);
+    border: 1px solid var(--border-2);
+    border-radius: 6px;
+    padding: 2px 8px;
+    cursor: pointer;
+    font: inherit;
+}
+table#table-link-patterns td button:hover { background: var(--border); }
+/* Edit / Delete buttons render a single emoji glyph; size them as a square
+   so the icon stays centered and the column doesn't grow with text width. */
+table#table-link-patterns td button.button-edit,
+table#table-link-patterns td button.button-delete {
+    width: 28px;
+    height: 28px;
+    padding: 0;
+    font-size: 14px;
+    line-height: 1;
+}
+table#table-link-patterns td button.button-delete:hover {
+    background: var(--danger-bg);
+    border-color: var(--danger-fg);
+}
+/* Reorder column has two stacked arrow buttons. */
+table#table-link-patterns td button.button-reorder-up,
+table#table-link-patterns td button.button-reorder-down {
+    padding: 0 6px;
+    font-size: 10px;
+    line-height: 1.4;
+    margin: 0 1px;
 }
 
-table#table-link-patterns th {
-    font-size: 15px;
-    background-color: rgb(32, 37, 45);
-    padding: 10px;
+/* Import / Export row. */
+.io-row {
+    display: flex;
+    align-items: end;
+    gap: var(--s-4);
+    flex-wrap: wrap;
+}
+.io-row__buttons {
+    display: flex;
+    gap: var(--s-2);
+    margin-left: auto;
 }
 
-table tr.editing {
-    background-color: rgb(179 0 0 / 18%);
+/* Append / Overwrite radio group. Uses a fieldset+legend so screen readers
+   announce the group label. */
+fieldset.radio-set {
+    border: 1px solid var(--border-2);
+    border-radius: var(--radius);
+    padding: 4px 12px 6px;
+    margin: 0;
+    display: flex;
+    gap: var(--s-3);
+    align-items: center;
+}
+.radio-set legend {
+    padding: 0 4px;
+    color: var(--muted);
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.5px;
+    text-transform: uppercase;
+}
+.radio-set label {
+    display: flex;
+    align-items: center;
+    gap: var(--s-1);
+    cursor: pointer;
+    font-size: 13px;
+    color: var(--text);
+}
+input[type="radio"] {
+    appearance: none;
+    -webkit-appearance: none;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    border: 1px solid var(--border-2);
+    background: var(--panel-2);
+    cursor: pointer;
+    position: relative;
+    margin: 0;
+}
+input[type="radio"]:checked { border-color: var(--accent); }
+input[type="radio"]:checked::after {
+    content: "";
+    position: absolute;
+    inset: 3px;
+    background: var(--accent);
+    border-radius: 50%;
+}
+
+/* Narrow-viewport collapse: 2-col grids drop to one column. */
+@media (max-width: 720px) {
+    .globals { grid-template-columns: 1fr; }
+    .form-grid,
+    .form-grid--three,
+    .form-grid--title-pattern,
+    .toggle-list--grid { grid-template-columns: 1fr; }
+    .io-row__buttons { margin-left: 0; }
 }

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -126,10 +126,12 @@
                                         aria-label="Show date: include the timestamp of the comment that contained the link."
                                         title="Includes the timestamp of the comment that contained the link.">?</button>
                             </div>
-                        </div>
-
-                        <div class="form-actions form-actions--end">
-                            <button type="submit" id="button-save-link-patterns" class="btn btn--primary">Save Link Pattern</button>
+                            <!-- Save sits on the same inline row as the
+                                 Summary type / toggles, pushed to the
+                                 right via margin-left: auto. Keeps the
+                                 form compact instead of dropping the
+                                 button onto its own line below. -->
+                            <button type="submit" id="button-save-link-patterns" class="btn btn--primary form-inline-submit">Save Link Pattern</button>
                         </div>
 
                         <div id="container-link-patterns-error">

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -29,38 +29,40 @@
                 <h2 id="h-globals">Global settings</h2>
                 <p>These apply to every Zendesk ticket.</p>
             </div>
+            <!--
+              2-column grid of single-line toggle rows. Each row is a flex
+              container of [checkbox][label][?] — no nested grids, no
+              display:contents. Order in source = visual order top-to-bottom,
+              column-by-column.
+            -->
             <div class="toggle-list toggle-list--grid">
-                <div class="toggle-col">
-                    <div class="toggle-row toggle-row--inline">
-                        <input type="checkbox" id="wrap-lists">
-                        <label for="wrap-lists" class="toggle-row__label toggle-row__label--lg">Wrap long URLs</label>
-                        <button type="button" class="help-tip"
-                                aria-label="Wrap long URLs: wrap long URLs in the popup instead of horizontal scrolling."
-                                title="Wrap long URLs in the popup instead of horizontal scrolling.">?</button>
-                    </div>
-                    <div class="toggle-row toggle-row--inline">
-                        <input type="checkbox" id="include-attachments">
-                        <label for="include-attachments" class="toggle-row__label toggle-row__label--lg">Include attachments</label>
-                        <button type="button" class="help-tip"
-                                aria-label="Include attachments: include attachment links in the markdown summary."
-                                title="Includes attachment links in the markdown summary.">?</button>
-                    </div>
+                <div class="toggle-row">
+                    <input type="checkbox" id="wrap-lists">
+                    <label for="wrap-lists" class="toggle-row__label">Wrap long URLs</label>
+                    <button type="button" class="help-tip"
+                            aria-label="Wrap long URLs: wrap long URLs in the popup instead of horizontal scrolling."
+                            title="Wrap long URLs in the popup instead of horizontal scrolling.">?</button>
                 </div>
-                <div class="toggle-col">
-                    <div class="toggle-row toggle-row--inline">
-                        <input type="checkbox" id="background-processing">
-                        <label for="background-processing" class="toggle-row__label toggle-row__label--lg">Run in background</label>
-                        <button type="button" class="help-tip"
-                                aria-label="Run in background: pre-collect links while a Zendesk tab loads. Faster popup, more API calls."
-                                title="Pre-collects links while a Zendesk tab loads. Faster popup, more API calls.">?</button>
-                    </div>
-                    <div class="toggle-row toggle-row--inline">
-                        <input type="checkbox" id="include-images">
-                        <label for="include-images" class="toggle-row__label toggle-row__label--lg">Include images</label>
-                        <button type="button" class="help-tip"
-                                aria-label="Include images: include image links in the markdown summary."
-                                title="Includes image links in the markdown summary.">?</button>
-                    </div>
+                <div class="toggle-row">
+                    <input type="checkbox" id="background-processing">
+                    <label for="background-processing" class="toggle-row__label">Run in background</label>
+                    <button type="button" class="help-tip"
+                            aria-label="Run in background: pre-collect links while a Zendesk tab loads. Faster popup, more API calls."
+                            title="Pre-collects links while a Zendesk tab loads. Faster popup, more API calls.">?</button>
+                </div>
+                <div class="toggle-row">
+                    <input type="checkbox" id="include-attachments">
+                    <label for="include-attachments" class="toggle-row__label">Include attachments</label>
+                    <button type="button" class="help-tip"
+                            aria-label="Include attachments: include attachment links in the markdown summary."
+                            title="Includes attachment links in the markdown summary.">?</button>
+                </div>
+                <div class="toggle-row">
+                    <input type="checkbox" id="include-images">
+                    <label for="include-images" class="toggle-row__label">Include images</label>
+                    <button type="button" class="help-tip"
+                            aria-label="Include images: include image links in the markdown summary."
+                            title="Includes image links in the markdown summary.">?</button>
                 </div>
             </div>
             <div class="form-actions form-actions--end" id="input-container-save-options">
@@ -110,14 +112,14 @@
                                     <option value="all">All</option>
                                 </select>
                             </div>
-                            <div class="toggle-row toggle-row--inline">
+                            <div class="toggle-row">
                                 <input type="checkbox" id="show-parent">
                                 <label for="show-parent" class="toggle-row__label">Show context</label>
                                 <button type="button" class="help-tip"
                                         aria-label="Show context: include the surrounding text from the comment where the link was found."
                                         title="Includes the surrounding text from the comment where the link was found.">?</button>
                             </div>
-                            <div class="toggle-row toggle-row--inline">
+                            <div class="toggle-row">
                                 <input type="checkbox" id="show-date">
                                 <label for="show-date" class="toggle-row__label">Show date</label>
                                 <button type="button" class="help-tip"

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -1,84 +1,293 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<title>Options Page</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Zendesk Link Collector — Options</title>
     <link rel="stylesheet" href="options.css">
 </head>
 <body>
-	<h1>Options Page</h1>
-    <div class="input-container-column">
-        <div class="input-container-row">
-            <label class="input-label" title="How to handle links that are too long to be displayed in the extension.&#13&#13Enabled = wrap long links.&#13Disabled = scroll long links." for="wrap-lists">Wrap long links?</label>
-            <input type="checkbox" id="wrap-lists">
+    <!--
+      Layout: a single 1024px column. Each top-level <section> is a card
+      (background + border + padding) with its heading + lede in the same panel.
+      The Patterns section nests three sub-cards (add form, examples, rules)
+      inside a .stack so they read as related grouped tools.
+    -->
+    <header class="page-header">
+        <div class="shell">
+            <p class="eyebrow">Browser extension options</p>
+            <h1>Zendesk Link Collector</h1>
+            <p class="lede">Configure how links are collected from Zendesk tickets and how they appear in the popup and markdown summary.</p>
         </div>
-        <div id="input-container-attachments" class="input-container-row">
-            <label class="input-label" title="Include attachments in the markdown summary." for="include-attachments">Include Attachments:</label>
-            <input type="checkbox" id="include-attachments">
-            <label class="input-label" title="Include images in the markdown summary." for="include-images">Include Images:</label>
-            <input type="checkbox" id="include-images">
-        </div>
-    </div>
-    <div id="input-container-save-options" class="input-container-row">
-        <button id="button-save-global-options">Save Options</button>
-    </div>
-    <div id="table-container-link-patterns">
-        <h1>Saved Link Patterns</h1>
-        <div id="input-container-link-patterns" class="input-container-row">
-            <label class="input-label" title="The heading to group links that match the pattern.&#13&#13This is a required field" for="title">Title:</label>
-            <input type="text" id="title" placeholder="Title">
-            <label class="input-label" title="The regex pattern to use for matching links in the ticket. Links matching this pattern will be collected and displayed in the extension.&#13&#13This is a required field." for="pattern">Pattern:</label>
-            <input type="text" id="pattern" placeholder="RegEx Pattern">
-            <label class="input-label" title="Show the context surrounding the link.&#13&#13Disabled = only the link is collected and displayed in the extension.&#13Enabled = the plain text surrounding the link will also be displayed in the extension." for="show-parent">Show Context:</label>
-            <input type="checkbox" id="show-parent">
-            <label class="input-label" title="How to summarize links found by this pattern when copying the markdown summary to clipboard.&#13&#13All = all links found will by copied.&#13Latest = only the most recent links will be copied&#13None = no links under this heading are copied (the heading will also be excluded)." for="summary-type">Summary Type:</label>
-            <select id="summary-type">
-                <option value="none" selected>None</option>
-                <option value="latest">Latest</option>
-                <option value="all">All</option>
-            </select>
-            <label class="input-label" title="Show the comment date where the link was found." for="show-date">Show Date:</label>
-            <input type="checkbox" id="show-date">
-            <button id="button-save-link-patterns">Save Link Pattern</button>
-        </div>
-        <h2>Example Patterns</h2>
-        <div>
-            <pre>https:\/\/docs\.github\.com</pre>
-            <pre>https:\/\/github\.com\/orgs\/community\/discussions</pre>
-            <pre>https:\/\/[A-Za-z0-9]+\.zendesk\.com\/agent\/tickets\/[0-9]+</pre>
-        </div>
-        <div id="container-link-patterns-error" class="input-container-row">
-            <div class="hidden" id="link-patterns-error">Error: this is an error</div>
-        </div>
-        <table id="table-link-patterns">
-            <thead>
-            <tr>
-                <th>Title</th>
-                <th>Pattern</th>
-                <th>Show Context</th>
-                <th>Summary Type</th>
-                <th>Show Date</th>
-                <th>Edit</th>
-                <th>Delete</th>
-                <th>Reorder</th>
-            </tr>
-            </thead>
-            <tbody>
-            </tbody>
-        </table>
-    </div>
-    <h2>Import/Export</h2>
-    <div class="input-container-row input-container-import-export" id="input-container-link-patterns-import-export">
-        <label for="link-patterns-import-file">Import File: </label>
-        <input type="file" id="link-patterns-import-file" name="link-patterns-import-file" accept=".json">
-        <label class="input-label" title="How to import link patterns and options.&#13&#13Append = keep all existing data add add patterns to the end.&#13Overwrite = delete all link patterns and load only the patterns in the import file." for="link-patterns-import-type">Import Type: </label>
-        <select id="link-patterns-import-type" name="link-patterns-import-type">
-            <option value="append" selected>Append</option>
-            <option value="overwrite">Overwrite</option>
-        </select>
-        <button type="button" id="link-patterns-import">Import</button>
-        <button type="button" id="link-patterns-export">Export</button>
-    </div>
-    <script type="application/javascript" src="../lib/browser-polyfill.min.js"></script>
-	<script type="application/javascript" src="options.js"></script>
+    </header>
+
+    <main class="shell">
+
+        <!-- Section 1: Global settings -->
+        <section class="section" id="section-globals" aria-labelledby="h-globals">
+            <div class="section__head">
+                <h2 id="h-globals">Global settings</h2>
+                <p>These apply to every Zendesk ticket.</p>
+            </div>
+            <div class="toggle-list toggle-list--grid">
+                <div class="toggle-col">
+                    <div class="toggle-row toggle-row--inline">
+                        <input type="checkbox" id="wrap-lists">
+                        <label for="wrap-lists" class="toggle-row__label toggle-row__label--lg">Wrap long URLs</label>
+                        <button type="button" class="help-tip"
+                                aria-label="Wrap long URLs: wrap long URLs in the popup instead of horizontal scrolling."
+                                title="Wrap long URLs in the popup instead of horizontal scrolling.">?</button>
+                    </div>
+                    <div class="toggle-row toggle-row--inline">
+                        <input type="checkbox" id="include-attachments">
+                        <label for="include-attachments" class="toggle-row__label toggle-row__label--lg">Include attachments</label>
+                        <button type="button" class="help-tip"
+                                aria-label="Include attachments: include attachment links in the markdown summary."
+                                title="Includes attachment links in the markdown summary.">?</button>
+                    </div>
+                </div>
+                <div class="toggle-col">
+                    <div class="toggle-row toggle-row--inline">
+                        <input type="checkbox" id="background-processing">
+                        <label for="background-processing" class="toggle-row__label toggle-row__label--lg">Run in background</label>
+                        <button type="button" class="help-tip"
+                                aria-label="Run in background: pre-collect links while a Zendesk tab loads. Faster popup, more API calls."
+                                title="Pre-collects links while a Zendesk tab loads. Faster popup, more API calls.">?</button>
+                    </div>
+                    <div class="toggle-row toggle-row--inline">
+                        <input type="checkbox" id="include-images">
+                        <label for="include-images" class="toggle-row__label toggle-row__label--lg">Include images</label>
+                        <button type="button" class="help-tip"
+                                aria-label="Include images: include image links in the markdown summary."
+                                title="Includes image links in the markdown summary.">?</button>
+                    </div>
+                </div>
+            </div>
+            <div class="form-actions form-actions--end" id="input-container-save-options">
+                <button id="button-save-global-options" class="btn btn--primary">Save Options</button>
+            </div>
+        </section>
+
+        <!-- Section 2: Link patterns. Nests three sub-cards: Add, Examples, Rules. -->
+        <section class="section" id="section-patterns" aria-labelledby="h-patterns">
+            <div class="section__head">
+                <h2 id="h-patterns">Link patterns</h2>
+                <p>Rules that match URLs in tickets and decide how they are grouped, summarized, and dated.</p>
+            </div>
+
+            <div class="stack">
+
+                <!-- Sub-card: Add a pattern -->
+                <div class="subcard">
+                    <h3 class="subcard__title">Add a pattern</h3>
+                    <!-- Real <form> so Enter in any field submits naturally
+                         and assistive tech announces this as a form. The
+                         submit handler delegates to saveLinkPatterns and
+                         calls preventDefault to keep us on the page. -->
+                    <form class="pattern-form" id="input-container-link-patterns">
+                        <div class="form-grid form-grid--title-pattern">
+                            <div class="form-row">
+                                <label for="title">Title</label>
+                                <input type="text" id="title" placeholder="e.g. GitHub Docs">
+                            </div>
+                            <div class="form-row">
+                                <label for="pattern">Pattern <span class="muted">(regex)</span></label>
+                                <input type="text" id="pattern" class="mono" placeholder="https:\/\/example\.com\/\S+" spellcheck="false">
+                            </div>
+                        </div>
+
+                        <div class="form-grid--inline">
+                            <div class="form-row form-row--compact">
+                                <div class="label-with-help">
+                                    <label for="summary-type">Summary type</label>
+                                    <button type="button" class="help-tip"
+                                            aria-label="Summary type: how to summarize multiple matches of this pattern in the popup."
+                                            title="How to summarize multiple matches of this pattern in the popup. None: list all matches plainly. Latest: show only the most recent. All: show every match grouped together.">?</button>
+                                </div>
+                                <select id="summary-type">
+                                    <option value="none" selected>None</option>
+                                    <option value="latest">Latest</option>
+                                    <option value="all">All</option>
+                                </select>
+                            </div>
+                            <div class="toggle-row toggle-row--inline">
+                                <input type="checkbox" id="show-parent">
+                                <label for="show-parent" class="toggle-row__label">Show context</label>
+                                <button type="button" class="help-tip"
+                                        aria-label="Show context: include the surrounding text from the comment where the link was found."
+                                        title="Includes the surrounding text from the comment where the link was found.">?</button>
+                            </div>
+                            <div class="toggle-row toggle-row--inline">
+                                <input type="checkbox" id="show-date">
+                                <label for="show-date" class="toggle-row__label">Show date</label>
+                                <button type="button" class="help-tip"
+                                        aria-label="Show date: include the timestamp of the comment that contained the link."
+                                        title="Includes the timestamp of the comment that contained the link.">?</button>
+                            </div>
+                        </div>
+
+                        <div class="form-actions form-actions--end">
+                            <button type="submit" id="button-save-link-patterns" class="btn btn--primary">Save Link Pattern</button>
+                        </div>
+
+                        <div id="container-link-patterns-error">
+                            <!-- role=status is non-interrupting; live regex
+                                 validation feedback shouldn't pre-empt the
+                                 screen reader on every keystroke. -->
+                            <div class="hidden alert" id="link-patterns-error" role="status" aria-live="polite"></div>
+                        </div>
+                    </form>
+                </div>
+
+                <!-- Sub-card: Rules table. Rendered by options.js — preserves all required
+                     IDs and class hooks. -->
+                <div class="subcard subcard--flush">
+                    <h3 class="subcard__title subcard__title--padded">Rules</h3>
+                    <div id="table-container-link-patterns">
+                        <table id="table-link-patterns" class="data-table">
+                            <colgroup>
+                                <col class="col-title">
+                                <col class="col-pattern">
+                                <col class="col-bool">
+                                <col class="col-summary">
+                                <col class="col-bool">
+                                <col class="col-reorder">
+                                <col class="col-action">
+                                <col class="col-action">
+                            </colgroup>
+                            <thead>
+                                <tr>
+                                    <th scope="col">Title</th>
+                                    <th scope="col">Pattern</th>
+                                    <th scope="col">Context</th>
+                                    <th scope="col">Summary</th>
+                                    <th scope="col">Date</th>
+                                    <th scope="col">Reorder</th>
+                                    <th scope="col">Edit</th>
+                                    <th scope="col">Delete</th>
+                                </tr>
+                            </thead>
+                            <tbody></tbody>
+                        </table>
+                    </div>
+                </div>
+
+            </div>
+        </section>
+
+        <!-- Section 3: Import / Export -->
+        <section class="section" id="section-io" aria-labelledby="h-io">
+            <div class="section__head">
+                <h2 id="h-io">Import / Export</h2>
+                <p>Back up the configuration or load a teammate's.</p>
+            </div>
+            <div class="io-row" id="input-container-link-patterns-import-export">
+                <div class="form-row">
+                    <label for="link-patterns-import-file">Import file</label>
+                    <input type="file" id="link-patterns-import-file" name="link-patterns-import-file" accept=".json">
+                </div>
+                <fieldset class="radio-set">
+                    <legend>Import mode</legend>
+                    <label><input type="radio" name="link-patterns-import-type" value="append" checked> Append</label>
+                    <label><input type="radio" name="link-patterns-import-type" value="overwrite"> Overwrite</label>
+                </fieldset>
+                <div class="io-row__buttons">
+                    <button id="link-patterns-import" class="btn btn--primary">Import</button>
+                    <button id="link-patterns-export" class="btn">Export</button>
+                </div>
+            </div>
+            <!-- Status region for Import/Export. Lives in this section so its
+                 errors and "Imported N, skipped M" summary appear next to the
+                 controls that produced them, not in the Add Pattern box. -->
+            <div id="container-link-patterns-io-status">
+                <div class="hidden alert" id="link-patterns-io-status" role="status" aria-live="polite"></div>
+            </div>
+        </section>
+
+        <!-- Section 4: Example patterns. Lives at the bottom as a reference;
+             each row's "Import" button adds it to the rules with one click. -->
+        <section class="section" id="section-examples" aria-labelledby="h-examples">
+            <div class="section__head">
+                <h2 id="h-examples">Example patterns</h2>
+                <p>Common starting points. Tweak the settings on a row, then click Import to add it to your rules.</p>
+            </div>
+            <div class="subcard subcard--flush">
+                <table class="examples-table data-table">
+                    <thead>
+                        <tr>
+                            <th scope="col">Title</th>
+                            <th scope="col">Pattern</th>
+                            <th scope="col">Context</th>
+                            <th scope="col">Summary</th>
+                            <th scope="col">Date</th>
+                            <th scope="col">Import</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr class="example-row">
+                            <td>GitHub Docs</td>
+                            <td class="cell--pattern"><code>https://docs\.github\.com</code></td>
+                            <td><input type="checkbox" class="example-show-parent" checked aria-label="Show context"></td>
+                            <td>
+                                <select class="example-summary-type" aria-label="Summary type">
+                                    <option value="none">None</option>
+                                    <option value="latest">Latest</option>
+                                    <option value="all" selected>All</option>
+                                </select>
+                            </td>
+                            <td><input type="checkbox" class="example-show-date" aria-label="Show date"></td>
+                            <td><button type="button" class="btn btn--small button-import-example" title="Import this example as a rule" aria-label="Import GitHub Docs example">Import</button></td>
+                        </tr>
+                        <tr class="example-row">
+                            <td>Zendesk Tickets</td>
+                            <td class="cell--pattern"><code>https://[A-Za-z0-9]+\.zendesk\.com/agent/tickets/[0-9]+</code></td>
+                            <td><input type="checkbox" class="example-show-parent" aria-label="Show context"></td>
+                            <td>
+                                <select class="example-summary-type" aria-label="Summary type">
+                                    <option value="none">None</option>
+                                    <option value="latest" selected>Latest</option>
+                                    <option value="all">All</option>
+                                </select>
+                            </td>
+                            <td><input type="checkbox" class="example-show-date" aria-label="Show date"></td>
+                            <td><button type="button" class="btn btn--small button-import-example" title="Import this example as a rule" aria-label="Import Zendesk Tickets example">Import</button></td>
+                        </tr>
+                        <tr class="example-row">
+                            <td>Slack permalinks</td>
+                            <td class="cell--pattern"><code>https://[a-z0-9-]+\.slack\.com/archives/[A-Z0-9]+/p[0-9]+</code></td>
+                            <td><input type="checkbox" class="example-show-parent" checked aria-label="Show context"></td>
+                            <td>
+                                <select class="example-summary-type" aria-label="Summary type">
+                                    <option value="none" selected>None</option>
+                                    <option value="latest">Latest</option>
+                                    <option value="all">All</option>
+                                </select>
+                            </td>
+                            <td><input type="checkbox" class="example-show-date" checked aria-label="Show date"></td>
+                            <td><button type="button" class="btn btn--small button-import-example" title="Import this example as a rule" aria-label="Import Slack permalinks example">Import</button></td>
+                        </tr>
+                        <tr class="example-row">
+                            <td>GitLab Docs</td>
+                            <td class="cell--pattern"><code>https://docs\.gitlab\.com</code></td>
+                            <td><input type="checkbox" class="example-show-parent" checked aria-label="Show context"></td>
+                            <td>
+                                <select class="example-summary-type" aria-label="Summary type">
+                                    <option value="none">None</option>
+                                    <option value="latest">Latest</option>
+                                    <option value="all" selected>All</option>
+                                </select>
+                            </td>
+                            <td><input type="checkbox" class="example-show-date" aria-label="Show date"></td>
+                            <td><button type="button" class="btn btn--small button-import-example" title="Import this example as a rule" aria-label="Import GitLab Docs example">Import</button></td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+
+    </main>
+
+    <script src="../lib/browser-shim.js"></script>
+    <script src="options.js"></script>
 </body>
 </html>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -81,12 +81,16 @@ function loadLinkPatterns() {
       tdReorder.className = "cell--reorder";
       const buttonReorderUp = document.createElement("button");
       buttonReorderUp.setAttribute("class", "button-reorder-up");
-      buttonReorderUp.textContent = "Up";
+      buttonReorderUp.textContent = "▲";
+      buttonReorderUp.setAttribute("title", "Move up");
+      buttonReorderUp.setAttribute("aria-label", "Move up");
       tdReorder.appendChild(buttonReorderUp);
       // Create down button.
       const buttonReorderDown = document.createElement("button");
       buttonReorderDown.setAttribute("class", "button-reorder-down");
-      buttonReorderDown.textContent = "Down";
+      buttonReorderDown.textContent = "▼";
+      buttonReorderDown.setAttribute("title", "Move down");
+      buttonReorderDown.setAttribute("aria-label", "Move down");
       tdReorder.appendChild(buttonReorderDown);
       nodes.push(tdReorder);
 
@@ -230,7 +234,7 @@ function saveLinkPatterns() {
     // Validate RegEx.
     try {
       new RegExp(document.getElementById("pattern").value);
-    } catch (SyntaxError) {
+    } catch {
       setLinkPatternError(
         "Invalid RegEx pattern! - Great work! That's difficult to do! :D"
       );
@@ -517,110 +521,6 @@ function saveLinkPatternInline(id) {
   });
 }
 
-// Edit a link pattern from the link patterns table.
-function editLinkPattern(id) {
-  // Disable all buttons except the one being edited.
-  document
-    .querySelectorAll("#table-link-patterns td button")
-    .forEach((button) => {
-      button.disabled = true;
-    });
-
-  // Fill the input fields with the selected link pattern's current values.
-  browser.storage.sync.get("options").then((data) => {
-    const option = data.options.find((option) => option.id === id);
-    if (option) {
-      document.getElementById("title").value = option.title;
-      document.getElementById("pattern").value = option.pattern;
-      document.getElementById("show-parent").checked = option.showParent;
-      document.getElementById("summary-type").value =
-        option.summaryType || "none";
-      document.getElementById("show-date").checked = option.showDate || false;
-
-      // Post a message that we are editing.
-      setLinkPatternError(
-        `You are editing the "${option.title}" link pattern!`
-      );
-
-      document.getElementById(id).classList.add("editing");
-
-      // Change the Save button to an Update button.
-      const saveButton = document.getElementById("button-save-link-patterns");
-      saveButton.textContent = "Update Link Pattern";
-      saveButton.removeEventListener("click", saveLinkPatterns);
-      saveButton.setAttribute("editing", id);
-      saveButton.onclick = updateLinkPattern;
-    }
-  });
-}
-
-// Update an existing link pattern with the values from the input fields.
-function updateLinkPattern() {
-  const id = document
-    .getElementById("button-save-link-patterns")
-    .getAttribute("editing");
-  browser.storage.sync.get("options").then((data) => {
-    const optionIndex = data.options.findIndex((option) => option.id === id);
-    if (optionIndex !== -1) {
-      // Validate RegEx.
-      try {
-        new RegExp(document.getElementById("pattern").value);
-      } catch (SyntaxError) {
-        setLinkPatternError(
-          "Invalid RegEx pattern! - Great work! That's difficult to do! :D"
-        );
-        console.error("Invalid RegEx");
-        return;
-      }
-
-      // Update the link pattern with the new values.
-      data.options[optionIndex].title = document.getElementById("title").value;
-      data.options[optionIndex].pattern =
-        document.getElementById("pattern").value;
-      data.options[optionIndex].showParent =
-        document.getElementById("show-parent").checked;
-      data.options[optionIndex].summaryType =
-        document.getElementById("summary-type").value;
-      data.options[optionIndex].showDate =
-        document.getElementById("show-date").checked;
-
-      // Save the updated link patterns to storage.
-      browser.storage.sync.set({ options: data.options }).then(() => {
-        // Load the updated patterns table.
-        loadLinkPatterns();
-
-        // Reset input fields.
-        document.getElementById("title").value = "";
-        document.getElementById("pattern").value = "";
-        document.getElementById("pattern").dispatchEvent(new Event("input"));
-        document.getElementById("show-parent").checked = false;
-        document.getElementById("summary-type").value = "none";
-        document.getElementById("show-date").checked = false;
-
-        // Change the Update button back to a Save button.
-        const saveButton = document.getElementById("button-save-link-patterns");
-        saveButton.textContent = "Save Link Pattern";
-        saveButton.removeEventListener("click", updateLinkPattern);
-        saveButton.addEventListener("click", saveLinkPatterns);
-
-        //Clear the message that we are editing.
-        setLinkPatternError("");
-
-        //saveButton.onclick = saveLinkPatterns;
-
-        // Re-enable all edit buttons.
-        /* document
-          .querySelectorAll("#table-link-patterns td button")
-          .forEach((button) => {
-            if (button.textContent === "Edit") {
-              button.disabled = false;
-            }
-          }); */
-      });
-    }
-  });
-}
-
 // Export/Download link patterns as JSON.
 function downloadLinkPatternsJSON() {
   browser.storage.sync.get("options").then((data) => {
@@ -754,6 +654,8 @@ function saveGlobalOptions() {
 
     data.optionsGlobal.wrapLists =
       document.getElementById("wrap-lists").checked;
+    data.optionsGlobal.backgroundProcessing =
+      document.getElementById("background-processing").checked;
     data.optionsGlobal.includeAttachments = document.getElementById(
       "include-attachments"
     ).checked;
@@ -778,6 +680,8 @@ function loadGlobalOptions() {
     }
     document.getElementById("wrap-lists").checked =
       data.optionsGlobal.wrapLists;
+    document.getElementById("background-processing").checked =
+      data.optionsGlobal.backgroundProcessing || false;
     document.getElementById("include-attachments").checked =
       data.optionsGlobal.includeAttachments;
     document.getElementById("include-images").checked =

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -212,6 +212,27 @@ function setIoStatus(msg) {
   el.classList.add("hidden");
 }
 
+// Set the inline-edit error message for a specific row. The error region
+// lives inside td.cell--pattern so it sits directly under the pattern input
+// and inherits the editing-row highlight. Empty msg hides the region.
+//
+// Earlier the inline editor reused setLinkPatternError, which wrote into
+// the Add Pattern section's error box — visually disconnected from the row
+// being edited. (Flagged by an earlier rubber-duck pass on the options
+// redesign as "errors render in Add form's alert region (visually
+// disconnected)".)
+function setRowEditError(tr, msg) {
+  if (!tr) return;
+  const el = tr.querySelector(".row-edit-error");
+  if (!el) return;
+  el.textContent = msg || "";
+  if (msg) {
+    el.classList.remove("hidden");
+  } else {
+    el.classList.add("hidden");
+  }
+}
+
 // Save a new link pattern from user input values.
 function saveLinkPatterns() {
   if (document.getElementById("title").value == "") {
@@ -378,33 +399,46 @@ function editLinkPatternInline(id) {
     titleInput.setAttribute("aria-label", "Title");
     tdTitle.appendChild(titleInput);
 
-    // Pattern cell — replace the <pre> with a mono text input.
+    // Pattern cell — replace the <pre> with a mono text input. Input and
+    // a row-local error region live inside a vertical flex stack so the
+    // input visibly slides up when the error appears, without changing
+    // the cell's overall height (other rows / sections don't reflow).
     const tdPattern = tr.querySelector(".cell--pattern");
     tdPattern.innerHTML = "";
+    const patternStack = document.createElement("div");
+    patternStack.className = "row-edit-pattern-stack";
     const patternInput = document.createElement("input");
     patternInput.type = "text";
     patternInput.value = option.pattern;
     patternInput.className = "row-edit-pattern mono";
     patternInput.setAttribute("aria-label", "Pattern");
     patternInput.setAttribute("spellcheck", "false");
-    tdPattern.appendChild(patternInput);
+    patternStack.appendChild(patternInput);
 
-    // Live regex validation on the pattern input itself: same debounce as
-    // the Add form. Errors render in the shared error region.
+    const rowError = document.createElement("div");
+    rowError.className = "row-edit-error alert hidden";
+    rowError.setAttribute("role", "status");
+    rowError.setAttribute("aria-live", "polite");
+    patternStack.appendChild(rowError);
+
+    tdPattern.appendChild(patternStack);
+
+    // Live regex validation on the pattern input itself: same 300ms
+    // debounce as the Add form. Errors render in the row-local region.
     let timer = null;
     patternInput.addEventListener("input", () => {
       if (timer) clearTimeout(timer);
       timer = setTimeout(() => {
         const v = patternInput.value;
         if (v === "") {
-          setLinkPatternError("");
+          setRowEditError(tr, "");
           return;
         }
         try {
           new RegExp(v);
-          setLinkPatternError("");
+          setRowEditError(tr, "");
         } catch (e) {
-          setLinkPatternError(`Invalid regex: ${e.message}`);
+          setRowEditError(tr, `Invalid regex: ${e.message}`);
         }
       }, 300);
     });
@@ -453,20 +487,18 @@ function editLinkPatternInline(id) {
     cancelButton.setAttribute("aria-label", `Cancel editing ${option.title}`);
     deleteButton.parentNode.replaceChild(cancelButton, deleteButton);
     cancelButton.addEventListener("click", () => {
-      setLinkPatternError("");
+      // Re-render drops the row-local error region naturally.
       loadLinkPatterns();
     });
 
     // Keyboard ergonomics: Enter on either text input commits, Escape on
-    // either cancels. Escape is a single global listener bound just to
-    // this row's lifetime to keep state simple.
+    // either cancels. Bound per-row; the next render replaces the inputs.
     const onKey = (e) => {
       if (e.key === "Enter") {
         e.preventDefault();
         saveLinkPatternInline(id);
       } else if (e.key === "Escape") {
         e.preventDefault();
-        setLinkPatternError("");
         loadLinkPatterns();
       }
     };
@@ -493,13 +525,13 @@ function saveLinkPatternInline(id) {
   ).checked;
 
   if (!newTitle || !newPattern) {
-    setLinkPatternError("Title and pattern are required.");
+    setRowEditError(tr, "Title and pattern are required.");
     return;
   }
   try {
     new RegExp(newPattern);
   } catch (e) {
-    setLinkPatternError(`Invalid regex: ${e.message}`);
+    setRowEditError(tr, `Invalid regex: ${e.message}`);
     return;
   }
 
@@ -514,10 +546,9 @@ function saveLinkPatternInline(id) {
       summaryType: newSummaryType,
       showDate: newShowDate,
     };
-    browser.storage.sync.set({ options: data.options }).then(() => {
-      setLinkPatternError("");
-      loadLinkPatterns();
-    });
+    // loadLinkPatterns re-renders the table and drops the row-local error
+    // region naturally — no explicit clear needed.
+    browser.storage.sync.set({ options: data.options }).then(loadLinkPatterns);
   });
 }
 

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -18,8 +18,12 @@ function loadLinkPatterns() {
       const nodes = [];
 
       // Create table cells.
+      // Each cell gets a `cell--<name>` class hook so the inline-edit code
+      // can find the cell by name, not by numeric index. (Reordering columns
+      // shouldn't silently mis-route the saved values.)
       // Create title cell.
       const tdTitle = document.createElement("td");
+      tdTitle.className = "cell--title";
       const strong = document.createElement("strong");
       strong.textContent = option.title;
       tdTitle.appendChild(strong);
@@ -27,13 +31,17 @@ function loadLinkPatterns() {
 
       // Create pattern cell.
       const tdPattern = document.createElement("td");
+      tdPattern.className = "cell--pattern";
       const pre = document.createElement("pre");
       pre.textContent = option.pattern;
+      // Show the full pattern on hover when it's been visually clipped.
+      pre.setAttribute("title", option.pattern);
       tdPattern.appendChild(pre);
       nodes.push(tdPattern);
 
       // Create show parent cell.
       const tdContext = document.createElement("td");
+      tdContext.className = "cell--context";
       const checkboxContext = document.createElement("input");
       checkboxContext.setAttribute("type", "checkbox");
       checkboxContext.setAttribute("disabled", "true");
@@ -43,6 +51,7 @@ function loadLinkPatterns() {
 
       // Create summary type cell.
       const tdSummaryType = document.createElement("td");
+      tdSummaryType.className = "cell--summary";
       if (option.summaryType == "all") {
         tdSummaryType.textContent = "All";
       } else if (option.summaryType == "latest") {
@@ -56,8 +65,9 @@ function loadLinkPatterns() {
       }
       nodes.push(tdSummaryType);
 
-      // Create show parent cell.
+      // Create show date cell.
       const tdDate = document.createElement("td");
+      tdDate.className = "cell--date";
       const checkboxDate = document.createElement("input");
       checkboxDate.setAttribute("type", "checkbox");
       checkboxDate.setAttribute("disabled", "true");
@@ -65,25 +75,10 @@ function loadLinkPatterns() {
       tdDate.appendChild(checkboxDate);
       nodes.push(tdDate);
 
-      // Create edit cell.
-      const tdEdit = document.createElement("td");
-      const buttonEdit = document.createElement("button");
-      buttonEdit.textContent = "Edit";
-      buttonEdit.addEventListener("click", () => editLinkPattern(option.id));
-      tdEdit.appendChild(buttonEdit);
-      nodes.push(tdEdit);
-
-      // Create delete cell.
-      const tdDelete = document.createElement("td");
-      const buttonDelete = document.createElement("button");
-      buttonDelete.setAttribute("class", "button-delete");
-      buttonDelete.textContent = "Delete";
-      tdDelete.appendChild(buttonDelete);
-      nodes.push(tdDelete);
-
       // Create reorder cells.
       // Create up button.
       const tdReorder = document.createElement("td");
+      tdReorder.className = "cell--reorder";
       const buttonReorderUp = document.createElement("button");
       buttonReorderUp.setAttribute("class", "button-reorder-up");
       buttonReorderUp.textContent = "Up";
@@ -94,6 +89,32 @@ function loadLinkPatterns() {
       buttonReorderDown.textContent = "Down";
       tdReorder.appendChild(buttonReorderDown);
       nodes.push(tdReorder);
+
+      // Create edit cell. Click toggles the row into inline-edit mode; once
+      // editing, the same button (now ✓) saves the row's changes.
+      const tdEdit = document.createElement("td");
+      tdEdit.className = "cell--edit";
+      const buttonEdit = document.createElement("button");
+      buttonEdit.textContent = "✏️";
+      buttonEdit.setAttribute("class", "button-edit");
+      buttonEdit.setAttribute("title", "Edit");
+      buttonEdit.setAttribute("aria-label", `Edit ${option.title}`);
+      buttonEdit.addEventListener("click", () =>
+        editLinkPatternInline(option.id)
+      );
+      tdEdit.appendChild(buttonEdit);
+      nodes.push(tdEdit);
+
+      // Create delete cell.
+      const tdDelete = document.createElement("td");
+      tdDelete.className = "cell--delete";
+      const buttonDelete = document.createElement("button");
+      buttonDelete.setAttribute("class", "button-delete");
+      buttonDelete.textContent = "🗑️";
+      buttonDelete.setAttribute("title", "Delete");
+      buttonDelete.setAttribute("aria-label", `Delete ${option.title}`);
+      tdDelete.appendChild(buttonDelete);
+      nodes.push(tdDelete);
 
       // Add cells to row.
       tr.append(...nodes);
@@ -112,6 +133,10 @@ function loadLinkPatterns() {
         .querySelector(`[id = '${option.id}'] td button.button-reorder-down`)
         .addEventListener("click", () => reorderLinkPattern(option.id, 1));
     });
+    // Every render is also an exit from edit mode (Save, Cancel, Delete,
+    // Reorder, Add, Import all flow through here), so this is the natural
+    // place to clear the external lockout.
+    setEditLockState(false);
   });
 }
 
@@ -123,6 +148,64 @@ function setLinkPatternError(err) {
     return;
   }
   document.getElementById("link-patterns-error").classList.add("hidden");
+}
+
+// Lock or unlock every storage-mutating control that lives outside the
+// editing row, plus Export (so an unsaved draft can't lead to an export
+// that doesn't reflect what's on screen). Other rows' Edit/Delete/Reorder
+// buttons are locked separately inside editLinkPatternInline (they don't
+// exist outside an active table render).
+//
+// Every exit from edit mode (Save, Cancel, Delete, Reorder, Add, Import)
+// re-renders the rules table via loadLinkPatterns(), which calls this with
+// `false` at the end of render — so the unlock is automatic.
+function setEditLockState(locked) {
+  const externalSelectors = [
+    "#link-patterns-import",
+    "#link-patterns-export",
+    "#button-save-link-patterns",
+    ".button-import-example",
+  ];
+  const tooltip = "Finish or cancel the current edit first.";
+  externalSelectors.forEach((sel) => {
+    document.querySelectorAll(sel).forEach((btn) => {
+      if (locked) {
+        btn.setAttribute("disabled", "true");
+        btn.setAttribute("aria-disabled", "true");
+        // Stash any pre-existing title so unlock can restore it. Without
+        // this, buttons that ship with a baseline title (e.g. the example
+        // Import buttons) would lose their tooltip after the first
+        // lock/unlock cycle.
+        if (btn.hasAttribute("title") && !btn.dataset.titleBeforeLock) {
+          btn.dataset.titleBeforeLock = btn.getAttribute("title");
+        }
+        btn.setAttribute("title", tooltip);
+      } else {
+        btn.removeAttribute("disabled");
+        btn.removeAttribute("aria-disabled");
+        if (btn.dataset.titleBeforeLock) {
+          btn.setAttribute("title", btn.dataset.titleBeforeLock);
+          delete btn.dataset.titleBeforeLock;
+        } else {
+          btn.removeAttribute("title");
+        }
+      }
+    });
+  });
+}
+
+// Set the status message for the Import/Export section. Mirrors
+// setLinkPatternError but targets the io-status region so import errors and
+// the imported/skipped summary surface next to the Import/Export controls
+// instead of in the Add Pattern error box.
+function setIoStatus(msg) {
+  const el = document.getElementById("link-patterns-io-status");
+  el.textContent = msg;
+  if (msg != "" && msg != undefined) {
+    el.classList.remove("hidden");
+    return;
+  }
+  el.classList.add("hidden");
 }
 
 // Save a new link pattern from user input values.
@@ -170,6 +253,7 @@ function saveLinkPatterns() {
       // Reset input fields.
       document.getElementById("title").value = "";
       document.getElementById("pattern").value = "";
+      document.getElementById("pattern").dispatchEvent(new Event("input"));
       document.getElementById("show-parent").checked = false;
       document.getElementById("summary-type").value = "none";
       document.getElementById("show-date").checked = false;
@@ -227,6 +311,207 @@ function deleteLink(id) {
       }
     });
     browser.storage.sync.set({ options: data.options }).then(() => {
+      loadLinkPatterns();
+    });
+  });
+}
+
+// Switch a single rules-table row into inline-edit mode. Title and pattern
+// become text inputs; the disabled context/date checkboxes become live; the
+// summary cell's text becomes a <select>; the Edit button (✏️) becomes a
+// Save button (✓), and the Delete button (🗑️) becomes a Cancel button (✗).
+//
+// While editing, every storage-mutating control is locked out: other rows'
+// Edit/Delete/Reorder buttons, plus Import, example Imports, and Add
+// Pattern's Save (handled by setEditLockState). All exit paths re-render
+// the table via loadLinkPatterns(), which clears the locks. No popups; no
+// silent draft loss.
+function editLinkPatternInline(id) {
+  // Defensive guard. The lockout makes this path mostly unreachable, but
+  // keyboard / screen-reader users could still trigger it during the
+  // microtask gap between disabling buttons and the next render.
+  const otherEditing = document.querySelector(
+    "#table-link-patterns tr.editing"
+  );
+  if (otherEditing && otherEditing.id !== id) return;
+
+  browser.storage.sync.get("options").then((data) => {
+    const option = (data.options || []).find((o) => o.id === id);
+    if (!option) return;
+
+    const tr = document.getElementById(id);
+    if (!tr) return;
+
+    tr.classList.add("editing");
+
+    // Lock every other row's Edit/Delete/Reorder buttons. The current row's
+    // Edit button is morphed into ✓ Save and Delete into ✗ Cancel below; its
+    // own Reorder buttons stay enabled to match prior behavior.
+    const lockTooltip = "Finish or cancel the current edit first.";
+    document
+      .querySelectorAll("#table-link-patterns tbody tr")
+      .forEach((row) => {
+        if (row.id === id) return;
+        row
+          .querySelectorAll(
+            ".button-edit, .button-delete, .button-reorder-up, .button-reorder-down"
+          )
+          .forEach((btn) => {
+            btn.setAttribute("disabled", "true");
+            btn.setAttribute("aria-disabled", "true");
+            btn.setAttribute("title", lockTooltip);
+          });
+      });
+    setEditLockState(true);
+
+    // Title cell — replace the <strong> with a text input.
+    const tdTitle = tr.querySelector(".cell--title");
+    tdTitle.innerHTML = "";
+    const titleInput = document.createElement("input");
+    titleInput.type = "text";
+    titleInput.value = option.title;
+    titleInput.className = "row-edit-title";
+    titleInput.setAttribute("aria-label", "Title");
+    tdTitle.appendChild(titleInput);
+
+    // Pattern cell — replace the <pre> with a mono text input.
+    const tdPattern = tr.querySelector(".cell--pattern");
+    tdPattern.innerHTML = "";
+    const patternInput = document.createElement("input");
+    patternInput.type = "text";
+    patternInput.value = option.pattern;
+    patternInput.className = "row-edit-pattern mono";
+    patternInput.setAttribute("aria-label", "Pattern");
+    patternInput.setAttribute("spellcheck", "false");
+    tdPattern.appendChild(patternInput);
+
+    // Live regex validation on the pattern input itself: same debounce as
+    // the Add form. Errors render in the shared error region.
+    let timer = null;
+    patternInput.addEventListener("input", () => {
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => {
+        const v = patternInput.value;
+        if (v === "") {
+          setLinkPatternError("");
+          return;
+        }
+        try {
+          new RegExp(v);
+          setLinkPatternError("");
+        } catch (e) {
+          setLinkPatternError(`Invalid regex: ${e.message}`);
+        }
+      }, 300);
+    });
+
+    // Context checkbox — un-disable so the user can toggle.
+    tr.querySelector(".cell--context input[type='checkbox']").disabled = false;
+
+    // Summary cell — replace text with a <select>.
+    const tdSummary = tr.querySelector(".cell--summary");
+    tdSummary.innerHTML = "";
+    const summarySelect = document.createElement("select");
+    summarySelect.className = "row-edit-summary-type";
+    summarySelect.setAttribute("aria-label", "Summary type");
+    [
+      ["none", "None"],
+      ["latest", "Latest"],
+      ["all", "All"],
+    ].forEach(([value, label]) => {
+      const opt = new Option(label, value);
+      if (value === (option.summaryType || "none")) opt.selected = true;
+      summarySelect.add(opt);
+    });
+    tdSummary.appendChild(summarySelect);
+
+    // Date checkbox — un-disable.
+    tr.querySelector(".cell--date input[type='checkbox']").disabled = false;
+
+    // Edit button → Save (✓). cloneNode is the simplest way to drop the
+    // existing click handler without tracking it.
+    const editButton = tr.querySelector("button.button-edit");
+    const saveButton = editButton.cloneNode(false);
+    saveButton.textContent = "✓";
+    saveButton.className = "button-edit button-save";
+    saveButton.setAttribute("title", "Save changes");
+    saveButton.setAttribute("aria-label", `Save ${option.title}`);
+    editButton.parentNode.replaceChild(saveButton, editButton);
+    saveButton.addEventListener("click", () => saveLinkPatternInline(id));
+
+    // Delete button → Cancel (✗). Cancelling = re-render the table from
+    // storage; the original row reappears unchanged.
+    const deleteButton = tr.querySelector("button.button-delete");
+    const cancelButton = deleteButton.cloneNode(false);
+    cancelButton.textContent = "✗";
+    cancelButton.className = "button-delete button-cancel";
+    cancelButton.setAttribute("title", "Cancel edit");
+    cancelButton.setAttribute("aria-label", `Cancel editing ${option.title}`);
+    deleteButton.parentNode.replaceChild(cancelButton, deleteButton);
+    cancelButton.addEventListener("click", () => {
+      setLinkPatternError("");
+      loadLinkPatterns();
+    });
+
+    // Keyboard ergonomics: Enter on either text input commits, Escape on
+    // either cancels. Escape is a single global listener bound just to
+    // this row's lifetime to keep state simple.
+    const onKey = (e) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        saveLinkPatternInline(id);
+      } else if (e.key === "Escape") {
+        e.preventDefault();
+        setLinkPatternError("");
+        loadLinkPatterns();
+      }
+    };
+    titleInput.addEventListener("keydown", onKey);
+    patternInput.addEventListener("keydown", onKey);
+
+    titleInput.focus();
+  });
+}
+
+// Persist the inline-edited row back to storage and re-render the table.
+function saveLinkPatternInline(id) {
+  const tr = document.getElementById(id);
+  if (!tr) return;
+
+  const newTitle = tr.querySelector(".row-edit-title").value.trim();
+  const newPattern = tr.querySelector(".row-edit-pattern").value;
+  const newShowParent = tr.querySelector(
+    ".cell--context input[type='checkbox']"
+  ).checked;
+  const newSummaryType = tr.querySelector(".row-edit-summary-type").value;
+  const newShowDate = tr.querySelector(
+    ".cell--date input[type='checkbox']"
+  ).checked;
+
+  if (!newTitle || !newPattern) {
+    setLinkPatternError("Title and pattern are required.");
+    return;
+  }
+  try {
+    new RegExp(newPattern);
+  } catch (e) {
+    setLinkPatternError(`Invalid regex: ${e.message}`);
+    return;
+  }
+
+  browser.storage.sync.get("options").then((data) => {
+    const idx = data.options.findIndex((o) => o.id === id);
+    if (idx === -1) return;
+    data.options[idx] = {
+      ...data.options[idx],
+      title: newTitle,
+      pattern: newPattern,
+      showParent: newShowParent,
+      summaryType: newSummaryType,
+      showDate: newShowDate,
+    };
+    browser.storage.sync.set({ options: data.options }).then(() => {
+      setLinkPatternError("");
       loadLinkPatterns();
     });
   });
@@ -307,6 +592,7 @@ function updateLinkPattern() {
         // Reset input fields.
         document.getElementById("title").value = "";
         document.getElementById("pattern").value = "";
+        document.getElementById("pattern").dispatchEvent(new Event("input"));
         document.getElementById("show-parent").checked = false;
         document.getElementById("summary-type").value = "none";
         document.getElementById("show-date").checked = false;
@@ -353,72 +639,105 @@ function downloadLinkPatternsJSON() {
   });
 }
 
-// Import link patterns from JSON.
+// Import link patterns from JSON. Performs three layers of validation
+// before writing to storage so a malformed file can't replace good data:
+//   1. A file is actually selected.
+//   2. The file content parses as JSON and is an array.
+//   3. Each entry has the required fields and a compilable RegEx pattern.
+// Entries that fail the per-entry checks are dropped, not saved. The user
+// sees a summary in the inline error region (which doubles as a status
+// region for "imported N, skipped M").
 function importLinkPatternsJSON() {
   const inputElement = document.getElementById("link-patterns-import-file");
-  const file = inputElement.files[0];
+  const file = inputElement.files && inputElement.files[0];
+  if (!file) {
+    setIoStatus("Choose a JSON file to import first.");
+    return;
+  }
+
+  // Clear input so picking the same file again re-fires the change event.
+  inputElement.value = "";
+
   const fileReader = new FileReader();
-
-  // Clear input.
-  document.getElementById("link-patterns-import-file").value = "";
-
   fileReader.readAsText(file, "UTF-8");
   fileReader.onload = function () {
-    const fileContent = fileReader.result;
-    const newOptions = JSON.parse(fileContent);
-    const overwrite =
-      document.getElementById("link-patterns-import-type").value == "overwrite"
-        ? true
-        : false;
-    // Validate the JSON data.
+    let parsed;
+    try {
+      parsed = JSON.parse(fileReader.result);
+    } catch (e) {
+      setIoStatus(`Import failed: file is not valid JSON (${e.message}).`);
+      return;
+    }
+    if (!Array.isArray(parsed)) {
+      setIoStatus("Import failed: expected a JSON array of patterns.");
+      return;
+    }
 
-    newOptions.forEach((option) => {
-      // Check for missing fields.
+    const overwrite =
+      document.querySelector('input[name="link-patterns-import-type"]:checked')
+        .value === "overwrite";
+
+    // Filter — drop entries that don't have the required fields or that
+    // contain an uncompilable regex. Build a fresh, normalized list.
+    const validOptions = [];
+    let skipped = 0;
+    parsed.forEach((option) => {
       if (
-        option.id == undefined ||
+        !option ||
         option.title == undefined ||
         option.pattern == undefined ||
         option.showParent == undefined
       ) {
-        console.error("Invalid JSON data (missing fields)");
+        skipped += 1;
         return;
       }
-      // Set default summary type if not found.
-      if (option.summaryType == undefined) {
-        option.summaryType = "all";
-      }
-      // Always set new ID to avoid duplicates.
-      option.id = crypto.randomUUID();
-      // Validate RegEx.
       try {
         new RegExp(option.pattern);
-      } catch (SyntaxError) {
-        console.error("Invalid JSON data (bad pattern)");
+      } catch {
+        skipped += 1;
         return;
       }
+      validOptions.push({
+        // Always assign a fresh ID to avoid colliding with existing rules.
+        id: crypto.randomUUID(),
+        title: option.title,
+        pattern: option.pattern,
+        showParent: option.showParent,
+        summaryType: option.summaryType || "all",
+        showDate: option.showDate || false,
+      });
     });
 
-    // Add to existing data.
-    if (!overwrite) {
-      browser.storage.sync.get("options").then((data) => {
-        if (data.options == undefined || data.options.length <= 0) {
-          data.options = [];
-        }
-        data.options.push(...newOptions);
-        browser.storage.sync.set({ options: data.options }).then(() => {
-          loadLinkPatterns();
-        });
-      });
+    if (validOptions.length === 0) {
+      setIoStatus(
+        `Import failed: no valid patterns found (skipped ${skipped}).`
+      );
       return;
     }
 
-    browser.storage.sync.set({ options: newOptions }).then(() => {
+    const reportResult = () => {
+      setIoStatus(
+        skipped === 0
+          ? ""
+          : `Imported ${validOptions.length} pattern${validOptions.length === 1 ? "" : "s"}; skipped ${skipped} invalid.`
+      );
       loadLinkPatterns();
+    };
+
+    if (overwrite) {
+      browser.storage.sync.set({ options: validOptions }).then(reportResult);
+      return;
+    }
+    browser.storage.sync.get("options").then((data) => {
+      const existing = Array.isArray(data.options) ? data.options : [];
+      browser.storage.sync
+        .set({ options: existing.concat(validOptions) })
+        .then(reportResult);
     });
   };
 
   fileReader.onerror = function () {
-    console.error("Unable to read file");
+    setIoStatus("Import failed: unable to read file.");
   };
 }
 
@@ -474,15 +793,78 @@ document.addEventListener("DOMContentLoaded", () => {
     .addEventListener("click", saveGlobalOptions);
   loadGlobalOptions();
 
-  // Link patterns event listeners.
+  // Link patterns event listeners. The Add Pattern controls live inside a
+  // real <form>, so submit fires on Enter in any field as well as on the
+  // Save button click. preventDefault keeps us on the page.
   document
-    .getElementById("button-save-link-patterns")
-    .addEventListener("click", saveLinkPatterns);
+    .getElementById("input-container-link-patterns")
+    .addEventListener("submit", (e) => {
+      e.preventDefault();
+      saveLinkPatterns();
+    });
   document
     .getElementById("link-patterns-import")
     .addEventListener("click", importLinkPatternsJSON);
   document
     .getElementById("link-patterns-export")
     .addEventListener("click", downloadLinkPatternsJSON);
+
+  // Live regex validation: debounced so we don't recompile on every key.
+  // After 300 ms of idle typing we (a) show/clear the inline error and
+  // (b) toggle a red "invalid" style on the Save button — a quick visual
+  // signal that clicking it won't succeed. Empty input is silent so we
+  // don't nag before they've started typing.
+  const patternInput = document.getElementById("pattern");
+  const saveButton = document.getElementById("button-save-link-patterns");
+  let validationTimer = null;
+  const VALIDATION_DEBOUNCE_MS = 300;
+  const runPatternValidation = () => {
+    const value = patternInput.value;
+    if (value === "") {
+      setLinkPatternError("");
+      saveButton.classList.remove("btn--invalid");
+      return;
+    }
+    try {
+      new RegExp(value);
+      setLinkPatternError("");
+      saveButton.classList.remove("btn--invalid");
+    } catch (e) {
+      setLinkPatternError(`Invalid regex: ${e.message}`);
+      saveButton.classList.add("btn--invalid");
+    }
+  };
+  patternInput.addEventListener("input", () => {
+    if (validationTimer) clearTimeout(validationTimer);
+    validationTimer = setTimeout(runPatternValidation, VALIDATION_DEBOUNCE_MS);
+  });
+
   loadLinkPatterns();
+
+  // One-click import for the example-pattern rows. The Title and Pattern
+  // come from the row's text; the three settings come from the row's live
+  // form controls so the user can tweak the example before importing it.
+  document.querySelectorAll(".button-import-example").forEach((button) => {
+    button.addEventListener("click", () => {
+      const row = button.closest(".example-row");
+      if (!row) return;
+      const title = row.cells[0].textContent.trim();
+      const pattern = row.querySelector(".cell--pattern code").textContent;
+      const newOption = {
+        id: crypto.randomUUID(),
+        title: title,
+        pattern: pattern,
+        showParent: row.querySelector(".example-show-parent").checked,
+        summaryType: row.querySelector(".example-summary-type").value,
+        showDate: row.querySelector(".example-show-date").checked,
+      };
+      browser.storage.sync.get("options").then((data) => {
+        if (data.options == undefined || data.options.length <= 0) {
+          data.options = [];
+        }
+        data.options.push(newOption);
+        browser.storage.sync.set({ options: data.options }).then(loadLinkPatterns);
+      });
+    });
+  });
 });

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -20,10 +20,6 @@
         <img class="icon-button icon-invert" id="summary-copy" src="../icons/copy.svg" width="15px" height="15px">
         <span id="summary-text">Summary</span>
       </a>
-      <a href="#" title="Fetch and process ticket data in the background any time a new ticket is viewed, when a zendesk ticket browser tab is opened, and when link patterns change.&#13&#13This can result in better perceived load times, but can also result in more calls to Zendesk depending on your usage patterns." class="button button-sub" id="button-background-processing">
-        <input type="checkbox" id="background-processing">
-        <span for="background-processing">Run in Background</span>
-      </a>
       <a href="#" title="" class="button button-sub" id="button-refresh">
         <img class="icon-button" id="refresh" src="../icons/loader.svg" width="15px" height="15px">
         <span for="refresh">Refresh</span>

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -627,14 +627,10 @@ document.addEventListener("DOMContentLoaded", () => {
   // Otherwise, the background script will have the new ticket already and we can directly start.
   browser.storage.sync.get("optionsGlobal").then((data) => {
     if (data.optionsGlobal.backgroundProcessing) {
-      // Show that background processing is enabled.
-      // Directly load from ticket storage.
-      document.getElementById("background-processing").checked = true;
+      // Background processing is enabled — load directly from ticket storage.
       start();
     } else {
-      // Show that background processing is disabled.
-      // Send refresh request to background script.
-      document.getElementById("background-processing").checked = false;
+      // Background processing is disabled — request a refresh to fetch the current ticket.
       refresh();
     }
   });
@@ -657,38 +653,6 @@ document.addEventListener("DOMContentLoaded", () => {
   document.getElementById("button-summary").addEventListener("click", () => {
     writeSummaryClipboard();
   });
-
-  // Event listener to toggle background processing.
-  document
-    .getElementById("button-background-processing")
-    .addEventListener("click", (event) => {
-      const checkbox = document.getElementById("background-processing");
-      browser.storage.sync.get("optionsGlobal").then((data) => {
-        // If run in background is disabled, then enable it.
-        if (!data.optionsGlobal.backgroundProcessing) {
-          console.log("Enable background processing.");
-          data.optionsGlobal.backgroundProcessing = true;
-          browser.storage.sync
-            .set({
-              optionsGlobal: data.optionsGlobal,
-            })
-            .then(() => {
-              checkbox.checked = true;
-            });
-          return;
-        }
-        // If run in background is enabled, then disable it.
-        console.log("Disable background processing.");
-        data.optionsGlobal.backgroundProcessing = false;
-        browser.storage.sync
-          .set({
-            optionsGlobal: data.optionsGlobal,
-          })
-          .then(() => {
-            checkbox.checked = false;
-          });
-      });
-    });
 
   // Add event listener to the refresh button.
   document.getElementById("button-refresh").addEventListener("click", () => {


### PR DESCRIPTION
## Summary

Visual + UX overhaul of the options page. Replaces the single-stack form with a sectioned "B-console" layout (Globals, Link patterns, Import/Export, Examples), adds inline editing for existing rules, full inline help tooltips, and a slew of a11y and data-loss fixes that came out of multiple critique passes.

The single-step undo feature is split out into its own PR (#105 — depends on this one).

## Notes for reviewers

- 6 commits, 4 files. All changes scoped to `src/options/` plus a `.gitignore` addition for the local design-preview sandbox.
- Each commit is atomic and reviewable on its own. The trunk commit (1) is large because it introduces the redesign as a single coherent piece — every element it adds needs the styles and labels it adds in the same breath, so splitting further would mean shipping intermediate states with unstyled or unlabeled new elements. Subsequent commits are surgical refinements that each target one concrete issue.

### Commits in review order

1. **`61f4558` feat(options): redesign options page with sectioned layout, help tooltips, and inline-edit row** — the bulk of the visual + behavioral change. Sectioned layout with `<section class="section">` cards, real-`<button>` help tooltips that screen-reader and keyboard users can focus, the inline-edit-row mechanic with row-collision lockout, JSON-import errors routed to a status region in the Import/Export card (no `alert()`, no silent rule clobber), and a11y baseline (`<form>` wrap, `scope=col`, `role=status` for live-validation).

2. **`447da14` refactor(options): replace .toggle-row's nested grid + display:contents hack with one flex primitive** — drops the `.toggle-row--inline` override, the `.toggle-col` wrapper, the `display:contents` flatten hack, and the unused label/desc variants. The 2-column grid for the global-settings area moves to the parent (`.toggle-list--grid`); each cell is now just a flat `.toggle-row`.

3. **`c0f334d` feat(options): adopt B-console card chrome** — gradient panel, soft border, soft shadow on `.section`. Body type bumped to 1rem/1.45. Heading + lede sizing matched to the B-console preview.

4. **`8ab3b8c` chore(options): drop legacy edit-via-add-form code and orphan media-query selectors** — removes `editLinkPattern` / `updateLinkPattern` (superseded by inline-edit) and the `.globals` / `.form-grid--three` references in the narrow-viewport media query (selectors gone).

5. **`4f10fd8` feat(options): render inline-edit validation errors in the row being edited** — validation errors during inline edit (empty title/pattern, invalid regex) used to render in the Add Pattern section's status box. Now a row-local error region sits inside `td.cell--pattern` directly under the input. Also stabilizes alert-region layout so live validation doesn't reflow the surrounding page on every keystroke (fixed min-height on hidden alerts; tbody rows pre-sized to match the editing-row height).

6. **`520b760` feat(options): move Save Link Pattern button up to the toggles row** — Save now sits next to the toggle group instead of below the form.

## Test steps

1. `make dev`, load `build/firefox/manifest.json` as a Firefox temporary add-on and `build/chrome` as a Chrome unpacked extension. (Don't use `make build` for local testing — its artifacts use the release `gecko.id` and loading them can clobber your real `browser.storage` data.)
2. Open the options page (gear icon → Options).
3. Add a rule, edit it inline, delete it. Confirm normal flow.
4. Try to import a malformed JSON file — error should render in the Import/Export status region (not a popup alert) and should not nuke existing rules.
5. While inline-editing one row, click Edit on a second row — every storage-mutating control outside the editing row should be disabled with a "Finish or cancel the current edit first." tooltip.
6. Type an invalid regex in the inline-edit pattern input — error should appear in the row, not at the top of the form, and the rules table below should not jump.
7. Tab through the page with keyboard only. All controls reachable; help tooltips focus properly.

## Merge conflict expectation

This PR wholesale-rewrites `src/options/options.{html,css,js}`. If #88 (a11y pass) or #89 (toggle move) lands first and they touch the same files, GitHub will report a conflict on this PR. Resolution is **take this PR's version entirely** — the redesign was authored on top of those changes' intent and absorbs their behavior (a11y attributes, toggle relocation) into the new layout.
