### PR TITLE
chore: add ESLint linting via GitHub Actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,26 @@
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  eslint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "20"
+
+      # Install lint dependencies inline rather than committing package.json.
+      # This keeps the repository free of npm artifacts while still allowing
+      # CI to enforce code quality. Versions match what eslint.config.mjs needs.
+      - name: Install ESLint
+        run: npm install --no-save --no-package-lock eslint@^10 @eslint/js@^10 globals@^17
+
+      - name: Run ESLint
+        run: npx eslint src/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 # ZLC Specific
 build
 
+# Local config backups (never commit — contains personal patterns)
+zlc-config*.json
+zlc-patterns*.json
+
 # Dependencies (installed locally if running ESLint by hand;
 # CI installs inline so the repo never tracks them)
 node_modules
@@ -31,3 +35,6 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdisk
+
+# Design preview sandbox (never commit)
+design-previews/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 # ZLC Specific
 build
 
+# Dependencies (installed locally if running ESLint by hand;
+# CI installs inline so the repo never tracks them)
+node_modules
+
 # General
 .DS_Store
 .AppleDouble

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,34 @@
+import globals from "globals";
+import js from "@eslint/js";
+
+export default [
+  js.configs.recommended,
+  {
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: "script",
+      globals: {
+        ...globals.browser,
+        ...globals.webextensions,
+        // `browser` global — extension API namespace
+        browser: "readonly",
+        // Chrome APIs used directly in some files
+        chrome: "readonly",
+        // Chrome service worker global for loading scripts
+        importScripts: "readonly",
+      },
+    },
+    rules: {
+      // Keep it basic — flag real problems, not style preferences
+      "no-unused-vars": ["warn", { argsIgnorePattern: "^_", caughtErrorsIgnorePattern: "^_" }],
+      "no-undef": "error",
+      "no-redeclare": "error",
+      "no-constant-condition": "warn",
+      "no-empty": ["warn", { allowEmptyCatch: true }],
+    },
+  },
+  {
+    // Ignore build output and vendored libraries
+    ignores: ["build/**", "src/lib/**", "node_modules/**"],
+  },
+];

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -460,7 +460,7 @@ browser.tabs.onActivated.addListener((activeTab) => {
     if (
       !tab.url ||
       tab.url.search(
-        /^https:\/\/[\-_A-Za-z0-9]+\.zendesk.com\/agent\/tickets\/[0-9]+/i
+        /^https:\/\/[-_A-Za-z0-9]+\.zendesk.com\/agent\/tickets\/[0-9]+/i
       ) == -1
     ) {
       browser.action.disable(tab.id);
@@ -492,7 +492,7 @@ browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
   if (
     !tab.url ||
     tab.url.search(
-      /^https:\/\/[\-_A-Za-z0-9]+\.zendesk.com\/agent\/tickets\/[0-9]+/i
+      /^https:\/\/[-_A-Za-z0-9]+\.zendesk.com\/agent\/tickets\/[0-9]+/i
     ) == -1
   ) {
     browser.action.disable(tab.id);


### PR DESCRIPTION
## Summary

Adds ESLint to CI. Runs on every push to `main` and every pull request. Dependencies are installed inline by the workflow run, so no npm artifacts (`package.json`, `package-lock.json`, `node_modules`) need to be committed to the repo.

Also adds `eslint.config.mjs` (flat config) with the project's globals declared (`browser`, `webextensions`, plus extension-specific globals like `browser`, `chrome`, `importScripts`).

## Stacking note

This PR depends on #92 (regex fix). #92 silences the only `no-useless-escape` warning in the codebase; without it, the first CI run added by this PR would fail. The PR diff here shows both commits because cross-fork PRs can't base on a fork branch, but only the workflow + config files are new work:

```
.github/workflows/lint.yml         (new)
eslint.config.mjs                  (new)
.gitignore                         (adds node_modules + sibling-PR overlap blocks)
```

If #92 lands first, this PR's diff against `main` will be just those three files.

## Notes for reviewers

One own commit on top of #92's `08db511`.

**`d617dae` chore: add ESLint linting via GitHub Actions** — Workflow installs `eslint@^10`, `@eslint/js@^10`, and `globals@^17` inline (no committed lockfile), then runs `npx eslint src/`. The flat config in `eslint.config.mjs` declares the runtime globals the codebase actually uses (`browser`, `chrome`, `importScripts`) so the existing source passes without changes once #92 lands.

**`c532716` chore(gitignore): align with sibling PR additions** — Adds the `zlc-config*.json`, `zlc-patterns*.json`, and `design-previews/` blocks that PR #103 also adds, so the two PRs converge on merge instead of producing an add/add conflict.


## Test steps

1. Open a PR against this branch with a deliberate lint error → CI should fail.
2. Run `npx eslint src/` locally with `eslint@^10 @eslint/js@^10 globals@^17` installed → matches CI.
